### PR TITLE
feat: Introduce generic motion phases for multi-step mappings

### DIFF
--- a/docs/architekturentscheidungen.md
+++ b/docs/architekturentscheidungen.md
@@ -210,3 +210,40 @@ Diese Unterscheidung ist stabil genug, um sie als Renderer-Regel zu behandeln. S
 Diese Entscheidung bedeutet nicht, dass `scaleFactor` beliebig interpretiert werden darf. Die Kontextregel ist Teil des Framework-Verhaltens und muss in Preview und Export konsistent bleiben.
 
 Wenn später weitere Scale-Bedeutungen entstehen, etwa Squash, Pressed-State, Overshoot, gestaffelte Skalierung oder komponentenspezifische Scale-Keyframes, sollte ein explizites Feld wie `scaleMode` oder `scaleKeyframes` eingeführt werden.
+
+---
+
+## ADR-10: Mehrphasige Animationen über `motionPhases`
+
+### Entscheidung
+
+Mehrphasige Animationen werden im Framework über das optionale Feld `motionPhases` in `AnimationParams` modelliert. Eine Motion-Phase beschreibt einen sequenziellen Bewegungsschritt auf demselben animierten Hauptelement, zum Beispiel:
+
+- Einfahrt von unten
+- anschließender Shake
+- anschließender Nudge
+- anschließende Scale-Impulse
+
+Wenn `motionPhases` vorhanden ist, gilt diese Sequenz als primäre Bewegungsbeschreibung. Die flachen Bewegungsfelder wie `direction`, `translateFrom`, `keyframes`, `opacity` oder `scaleFactor` werden dann nicht zusätzlich auf oberster Parameterebene verwendet.
+
+### Begründung
+
+Die Toast-Mappings haben gezeigt, dass einige semantische Bewegungen nicht sauber durch ein einzelnes flaches Parameterobjekt beschrieben werden können:
+
+- `toast-feedback-error`: y-Einfahrt plus x-Shake
+- `toast-feedback-warning`: y-Einfahrt plus y-Nudge
+- `toast-attention-oneShot`: y-Einfahrt plus Scale-Impulse
+
+Diese Fälle waren in den POCs zunächst als gezielte Renderer-Sonderfälle umgesetzt. Das war für die frühe Prüfung vertretbar, hätte aber vor dem Hauptprototyp zu inkonsistenter Logik geführt: Die Mapping-Datenbank hätte nur einen Teil der tatsächlichen Bewegung beschrieben, während Preview und Export die fehlende Sequenzlogik hart codiert hätten.
+
+`motionPhases` verschiebt diese Sequenz wieder in das Framework-Modell. Dadurch beschreiben Mapping-Daten, Preview und Export dieselbe Struktur. Der Renderer muss nicht mehr wissen, dass bestimmte Toast-IDs besondere Fälle sind, sondern verarbeitet eine generische Phasenliste.
+
+### Abgrenzung
+
+`motionPhases` ist bewusst kein allgemeines Szenen- oder Target-Modell. Eine Phase beschreibt nur die Bewegung desselben Hauptelements. Komponenten mit mehreren Teilzielen, etwa Input mit Container, Label und Helper-Text, bleiben weiterhin komponentenspezifische Renderer-Fälle.
+
+Ein allgemeines Target-Modell wäre erst sinnvoll, wenn mehrere Komponenten regelmäßig interne Teilziele wie Backdrop, Panel, Icon, Label oder Content unabhängig voneinander animieren müssen.
+
+### Konsequenz
+
+POC 03 rendert mehrphasige Mappings nun generisch über `motionPhases`. POC 04 exportiert dieselbe Phasenstruktur generisch für Framer Motion und CSS. Die Mapping-Validierung prüft zusätzlich die Struktur der Phasen, unter anderem Keyframe-Längen, Monotonie der Zeiten und die Trennung von flachen Bewegungsfeldern und Phasenmodell.

--- a/docs/todos.md
+++ b/docs/todos.md
@@ -5,8 +5,7 @@ Diese Datei sammelt die noch relevanten technischen Punkte für POC 03, Export u
 ## Offene Reihenfolge
 
 1. Spring-Handling in den Hauptprototyp übernehmen.
-2. Mehrphasige Toast-Error-Animation in den Hauptprototyp übernehmen.
-3. Generisches Phasenmodell vor dem Hauptprototyp prüfen.
+2. Mehrphasige Toast-Animationen über `motionPhases` in den Hauptprototyp übernehmen.
 
 ## 1. Spring-Easing gesondert behandeln
 
@@ -30,28 +29,27 @@ TODO für den Hauptprototyp:
 - CSS-Export bei Spring mit Hinweis versehen und bewusst approximieren.
 - Kein neues Datenmodell nötig.
 
-## 2. Mehrphasige Toast-Error-Animation behandeln
+## 2. Mehrphasige Toast-Animationen über `motionPhases` behandeln
 
-Status: In POC 03 und POC 04 prototypisch als Sonderfall gelöst, später in den Hauptprototyp übernehmen.
+Status: In POC 03 und POC 04 über `motionPhases` gelöst, später in den Hauptprototyp übernehmen.
 
 Ursprünglicher Zustand:
 
-- `toast-feedback-error` ist zweiphasig:
-  - y-Einfahrt von unten
-  - x-Shake nach Ankunft
-- Ein naiver `direction`/`keyframes`-Renderer reicht dafür nicht aus, weil `direction: "y"` die Einfahrt beschreibt, die Keyframes aber den anschließenden x-Shake.
+- Mehrphasige Toast-Mappings wurden zunächst als Renderer-Sonderfälle behandelt.
+- Ein naiver `direction`/`keyframes`-Renderer reicht dafür nicht aus, weil mehrere Bewegungsphasen unterschiedliche Eigenschaften oder Achsen verwenden.
 
 Umsetzung in den POCs:
 
-- POC 03 rendert `toast-feedback-error` als zweiphasige Preview-Sequenz.
-- POC 04 exportiert `toast-feedback-error` als zweiphasige Framer-Motion-Sequenz.
-- POC 04 erzeugt für CSS kombinierte Keyframes mit y-Einfahrt und anschließendem x-Shake.
+- `types.ts` enthält `motionPhases` als generisches Phasenmodell.
+- `toast-feedback-error`, `toast-feedback-warning` und `toast-attention-oneShot` nutzen `motionPhases`.
+- POC 03 rendert `motionPhases` generisch in der Preview.
+- POC 04 exportiert `motionPhases` generisch für Framer Motion und CSS.
 
 TODO für den Hauptprototyp:
 
-- Für die erste Editor-Implementierung reicht ein gezielter Sonderfall im Toast-Renderer und Export.
-- Kein `stages`-Modell vor dem Hauptprototyp einführen.
-- `stages` oder ein allgemeines Phasenmodell erst prüfen, wenn mehrere mehrphasige Mappings entstehen.
+- `motionPhases` in den Hauptprototyp übernehmen.
+- Keine neuen Toast-ID-Sonderfälle mehr einführen.
+- Preview und Export direkt auf dem generischen Phasenmodell aufbauen.
 
 <!-- ## 3. POC 03 als vollständiges Mapping-Review-Werkzeug nutzen
 
@@ -142,9 +140,9 @@ Ergebnis:
 - POC 05 Build erfolgreich ausgeführt.
 - Keine zusätzliche Export-Logik nötig, weil die Rationale-Änderungen direkt aus `mappings.ts` übernommen werden. -->
 
-## 3. Generisches Phasenmodell vor dem Hauptprototyp prüfen
+<!-- ## 3. Generisches Phasenmodell vor dem Hauptprototyp prüfen
 
-Status: Offen, vor dem Hauptprototyp entscheiden.
+Status: Erledigt.
 
 Aktuell werden bereits mehrere Toast-Mappings als gezielte Renderer-Sonderfälle behandelt:
 
@@ -167,9 +165,9 @@ Mögliche Modellrichtungen:
 
 Entscheidung:
 
-- Für den aktuellen POC bleiben gezielte Sonderfälle zulässig.
-- Vor dem Hauptprototyp aktiv entscheiden, ob `motionPhases` oder `secondaryMotion` eingeführt wird.
-- Falls weitere mehrphasige Mappings entstehen, sollte ein generisches Modell bevorzugt werden.
+- `motionPhases` wurde eingeführt.
+- POC 03 und POC 04 verwenden keine Toast-ID-Sonderfälle mehr für die mehrphasigen Toast-Mappings.
+- Die Architekturentscheidung ist in `docs/architekturentscheidungen.md` als ADR-10 dokumentiert. -->
 
 <!-- ## 4. Input-Focus/Blur auf Framer-Motion-Controls umstellen
 
@@ -305,3 +303,4 @@ Prüfen, wenn:
 - Systematischen Mapping-Review der priorisierten Schwächen durchgeführt.
 - Export nach Mapping-Review geprüft: POC 04 Tests und POC 05 Build erfolgreich.
 - Input-Focus/Blur in POC 03 auf Framer-Motion-Controls umgestellt.
+- Generisches Phasenmodell `motionPhases` eingeführt und in POC 03/04 umgesetzt.

--- a/pocs/poc-02-mapping-db/src/validation.ts
+++ b/pocs/poc-02-mapping-db/src/validation.ts
@@ -9,6 +9,8 @@ import type {
   Dimension,
   MappingEntry,
   MappingQuery,
+  KeyframeSequence,
+  MotionPhase,
   Subcategory,
 } from "../../../prototyp/src/framework/types";
 import {
@@ -28,6 +30,119 @@ export type ValidationReport = {
 
 const componentIds = new Set<ComponentId>(COMPONENT_IDS);
 const dimensions = new Set<Dimension>(DIMENSIONS);
+
+function validateKeyframeSequence(
+  entryId: string,
+  label: string,
+  sequence: KeyframeSequence,
+): string[] {
+  const errors: string[] = [];
+  const { values, times } = sequence;
+
+  if (values.length !== times.length) {
+    errors.push(`${entryId}: ${label} values/times length mismatch`);
+  }
+
+  if (times[0] !== 0 || times[times.length - 1] !== 1) {
+    errors.push(`${entryId}: ${label} times must start at 0 and end at 1`);
+  }
+
+  for (let index = 1; index < times.length; index += 1) {
+    if (times[index] < times[index - 1]) {
+      errors.push(`${entryId}: ${label} times must be monotonic`);
+    }
+  }
+
+  return errors;
+}
+
+function validateMotionPhase(
+  entry: MappingEntry,
+  phase: MotionPhase,
+): string[] {
+  const errors: string[] = [];
+  const phaseId = `${entry.id}.${phase.id}`;
+  const phaseHasTranslation =
+    phase.translatePx !== undefined ||
+    phase.translateDistance !== undefined ||
+    phase.translateFrom !== undefined ||
+    phase.translateTo !== undefined ||
+    phase.keyframes !== undefined;
+
+  if (!phase.id.trim()) {
+    errors.push(`${entry.id}: motion phase requires id`);
+  }
+
+  if (phase.duration <= 0) {
+    errors.push(`${phaseId}: motion phase duration must be greater than 0`);
+  }
+
+  if (phaseHasTranslation && phase.direction === undefined) {
+    errors.push(`${phaseId}: translation phase requires direction`);
+  }
+
+  if (
+    phase.translatePx !== undefined &&
+    phase.translateDistance !== undefined
+  ) {
+    errors.push(`${phaseId}: translatePx and translateDistance are exclusive`);
+  }
+
+  if (
+    (phase.translateFrom !== undefined || phase.translateTo !== undefined) &&
+    phase.translateDistance === undefined
+  ) {
+    errors.push(
+      `${phaseId}: translateFrom/translateTo require translateDistance`,
+    );
+  }
+
+  if (phase.keyframes !== undefined) {
+    errors.push(
+      ...validateKeyframeSequence(phaseId, "keyframe", phase.keyframes),
+    );
+  }
+
+  if (phase.scaleKeyframes !== undefined) {
+    errors.push(
+      ...validateKeyframeSequence(
+        phaseId,
+        "scale keyframe",
+        phase.scaleKeyframes,
+      ),
+    );
+  }
+
+  if (phase.opacityKeyframes !== undefined) {
+    errors.push(
+      ...validateKeyframeSequence(
+        phaseId,
+        "opacity keyframe",
+        phase.opacityKeyframes,
+      ),
+    );
+  }
+
+  const phaseEasing = phase.easing ?? entry.params.easing;
+  const usesSpring =
+    "preset" in phaseEasing && phaseEasing.preset === "spring";
+
+  if (
+    usesSpring &&
+    phase.springConfig === undefined &&
+    entry.params.springConfig === undefined
+  ) {
+    errors.push(`${phaseId}: spring phase requires springConfig`);
+  }
+
+  if (!usesSpring && phase.springConfig !== undefined) {
+    errors.push(
+      `${phaseId}: springConfig must only be used with spring easing`,
+    );
+  }
+
+  return errors;
+}
 
 export function validateMappingEntry(entry: MappingEntry): string[] {
   const errors: string[] = [];
@@ -116,40 +231,54 @@ export function validateMappingEntry(entry: MappingEntry): string[] {
   }
 
   if (params.keyframes !== undefined) {
-    const { values, times } = params.keyframes;
-
-    if (values.length !== times.length) {
-      errors.push(`${entry.id}: keyframe values/times length mismatch`);
-    }
-
-    if (times[0] !== 0 || times[times.length - 1] !== 1) {
-      errors.push(`${entry.id}: keyframe times must start at 0 and end at 1`);
-    }
-
-    for (let index = 1; index < times.length; index += 1) {
-      if (times[index] < times[index - 1]) {
-        errors.push(`${entry.id}: keyframe times must be monotonic`);
-      }
-    }
+    errors.push(
+      ...validateKeyframeSequence(entry.id, "keyframe", params.keyframes),
+    );
   }
 
   if (params.opacityKeyframes !== undefined) {
-    const { values, times } = params.opacityKeyframes;
+    errors.push(
+      ...validateKeyframeSequence(
+        entry.id,
+        "opacity keyframe",
+        params.opacityKeyframes,
+      ),
+    );
+  }
 
-    if (values.length !== times.length) {
-      errors.push(`${entry.id}: opacity keyframe values/times length mismatch`);
+  if (params.motionPhases !== undefined) {
+    const hasFlatMotion =
+      params.direction !== undefined ||
+      params.translatePx !== undefined ||
+      params.translateDistance !== undefined ||
+      params.translateFrom !== undefined ||
+      params.translateTo !== undefined ||
+      params.scaleFactor !== undefined ||
+      params.trackFactor !== undefined ||
+      params.keyframes !== undefined ||
+      params.opacity !== undefined ||
+      params.opacityKeyframes !== undefined ||
+      params.delay !== undefined;
+
+    if (params.motionPhases.length === 0) {
+      errors.push(`${entry.id}: motionPhases must not be empty`);
     }
 
-    if (times[0] !== 0 || times[times.length - 1] !== 1) {
+    if (hasFlatMotion) {
       errors.push(
-        `${entry.id}: opacity keyframe times must start at 0 and end at 1`,
+        `${entry.id}: motionPhases must not be mixed with flat motion fields`,
       );
     }
 
-    for (let index = 1; index < times.length; index += 1) {
-      if (times[index] < times[index - 1]) {
-        errors.push(`${entry.id}: opacity keyframe times must be monotonic`);
+    const phaseIds = new Set<string>();
+
+    for (const phase of params.motionPhases) {
+      if (phaseIds.has(phase.id)) {
+        errors.push(`${entry.id}: duplicate motion phase id "${phase.id}"`);
       }
+
+      phaseIds.add(phase.id);
+      errors.push(...validateMotionPhase(entry, phase));
     }
   }
 

--- a/pocs/poc-03-preview/README.md
+++ b/pocs/poc-03-preview/README.md
@@ -8,7 +8,7 @@ Dieses Verzeichnis validiert eine Preview-Komponente, die Mapping-Einträge als 
 
 ## Scope
 
-Aktueller Stand: implementierter Preview-POC mit Button-, Modal- und Toast-Preview.
+Aktueller Stand: implementierter Preview-POC für alle sechs Framework-Komponenten.
 
 Enthalten:
 
@@ -17,7 +17,7 @@ Enthalten:
 - Wiederholungslogik
 - direkte Anbindung an die aktuelle Mapping-Datenbank aus `prototyp/src/data/mappings.ts`
 - Motion-Adapter zur Übersetzung von `AnimationParams` in Framer-Motion-Controls
-- Sonderbehandlung für die zweiphasige `toast-feedback-error` Animation
+- generische Verarbeitung von `motionPhases` für mehrphasige Animationen
 
 Bewusst nicht enthalten:
 
@@ -40,7 +40,7 @@ Validieren, dass die Mapping-Datenbank aus POC 2 direkt als Animationsquelle fü
 
 ### Aufgaben
 
-- Preview-Komponenten für Button, Modal und Toast bauen
+- Preview-Komponenten für alle Framework-Komponenten bauen
 - Jede Komponente nimmt einen `MappingEntry` als Prop entgegen und spielt die dort definierten `AnimationParams` ab
 - Auswahl-UI bauen: Dropdown oder Button-Gruppe für Komponente und Bedeutungsdimension, direkt aus der Mapping-Datenbank generiert (keine hardcodierten Labels)
 - Animation wird bei jeder Änderung der Auswahl automatisch neu ausgelöst
@@ -56,7 +56,7 @@ Validieren, dass die Mapping-Datenbank aus POC 2 direkt als Animationsquelle fü
 
 - Auswahl einer neuen Kombination löst die Animation sofort aus
 - Wiederholungs-Button funktioniert zuverlässig
-- Alle drei Komponenten (Button, Modal, Toast) spielen ihre Animation korrekt ab
+- Alle sechs Framework-Komponenten spielen ihre Animation korrekt ab
 - Die Animationsparameter kommen ausschließlich aus der Mapping-Datenbank, keine hardcodierten Werte in den Preview-Komponenten
 
 ### Abgrenzung
@@ -66,9 +66,9 @@ Kein Code-Export, kein vollständiges Editor-UI, keine Begründungstexte im UI (
 ### Ergebnis
 
 - Auswahloptionen werden aus der Mapping-Datenbank generiert.
-- Button, Modal und Toast erhalten jeweils einen `MappingEntry` als Animationsquelle.
+- Button, Toggle, Toast, Modal, Input und Skeleton erhalten jeweils einen `MappingEntry` als Animationsquelle.
 - Bei jeder Auswahländerung wird die laufende Animation gestoppt, zurückgesetzt und neu abgespielt.
 - Der Replay-Button spielt dieselbe Mapping-Animation erneut ab, ohne Seitenreload.
 - Die Preview nutzt imperative Framer-Motion-Controls statt React-Remount per `key`.
 - Spring-Easing wird über `springConfig` behandelt.
-- `toast-feedback-error` wird als zweiphasige Sequenz gerendert: y-Einfahrt, danach x-Shake.
+- Mehrphasige Toast-Mappings werden über `motionPhases` generisch gerendert.

--- a/pocs/poc-03-preview/src/motionAdapter.ts
+++ b/pocs/poc-03-preview/src/motionAdapter.ts
@@ -3,6 +3,7 @@ import {
   EASING_CURVES,
   type ComponentId,
   type MappingEntry,
+  type MotionPhase,
   type TranslationEdge,
 } from "../../../prototyp/src/framework/types";
 import { getPreviewChoreography } from "./previewChoreography";
@@ -149,6 +150,38 @@ function getTransition(entry: MappingEntry): Transition {
   };
 }
 
+function getPhaseAxis(phase: MotionPhase): Axis {
+  return phase.direction ?? "y";
+}
+
+function getPhaseTransition(
+  entry: MappingEntry,
+  phase: MotionPhase,
+): Transition {
+  const easing = phase.easing ?? entry.params.easing;
+  const delay = phase.delay !== undefined ? phase.delay / 1000 : undefined;
+
+  if ("preset" in easing && easing.preset === "spring") {
+    const springConfig = phase.springConfig ?? entry.params.springConfig;
+
+    return {
+      delay,
+      type: "spring",
+      stiffness: springConfig?.stiffness,
+      damping: springConfig?.damping,
+      mass: springConfig?.mass,
+    };
+  }
+
+  const ease = "preset" in easing ? EASING_CURVES[easing.preset] : easing.cubicBezier;
+
+  return {
+    delay,
+    duration: phase.duration / 1000,
+    ease,
+  };
+}
+
 function getBaseTarget(entry: MappingEntry): TargetAndTransition {
   const target: TargetAndTransition = {
     x: 0,
@@ -191,6 +224,121 @@ function getInitialTarget(entry: MappingEntry): TargetAndTransition {
   }
 
   return target;
+}
+
+function getPhasedInitialTarget(entry: MappingEntry): TargetAndTransition {
+  const target: TargetAndTransition = {
+    x: 0,
+    y: 0,
+    scale: 1,
+    opacity: 1,
+  };
+  const firstPhase = entry.params.motionPhases?.[0];
+
+  if (firstPhase === undefined) {
+    return getInitialTarget(entry);
+  }
+
+  const axis = getPhaseAxis(firstPhase);
+  const size = getPreviewSize(entry.component);
+
+  if (firstPhase.opacity !== undefined) {
+    target.opacity = firstPhase.opacity[0];
+  }
+
+  if (firstPhase.opacityKeyframes !== undefined) {
+    target.opacity = firstPhase.opacityKeyframes.values[0];
+  }
+
+  if (firstPhase.scaleKeyframes !== undefined) {
+    target.scale = firstPhase.scaleKeyframes.values[0];
+  }
+
+  if (firstPhase.translateFrom !== undefined) {
+    target[axis] = edgeToValue(firstPhase.translateFrom, size);
+  }
+
+  if (firstPhase.translateTo !== undefined) {
+    target[axis] = 0;
+  }
+
+  if (firstPhase.keyframes !== undefined) {
+    target[axis] = firstPhase.keyframes.values[0];
+  }
+
+  return target;
+}
+
+function getPhaseAnimation(
+  entry: MappingEntry,
+  phase: MotionPhase,
+): TargetAndTransition {
+  const axis = getPhaseAxis(phase);
+  const size = getPreviewSize(entry.component);
+  const target: TargetAndTransition = {
+    transition: getPhaseTransition(entry, phase),
+  };
+  const times =
+    phase.keyframes?.times ??
+    phase.scaleKeyframes?.times ??
+    phase.opacityKeyframes?.times;
+
+  if (times !== undefined) {
+    target.transition = {
+      ...target.transition,
+      times,
+    };
+  }
+
+  if (phase.opacity !== undefined) {
+    target.opacity = phase.opacity[1];
+  }
+
+  if (phase.opacityKeyframes !== undefined) {
+    target.opacity = phase.opacityKeyframes.values;
+  }
+
+  if (phase.scaleKeyframes !== undefined) {
+    target.scale = phase.scaleKeyframes.values;
+  }
+
+  if (phase.translateFrom !== undefined) {
+    target[axis] = 0;
+  }
+
+  if (phase.translateTo !== undefined) {
+    target[axis] = edgeToValue(phase.translateTo, size);
+  }
+
+  if (phase.keyframes !== undefined) {
+    target[axis] = phase.keyframes.values;
+  }
+
+  if (phase.translatePx !== undefined) {
+    target[axis] = [0, phase.translatePx, 0];
+  }
+
+  return target;
+}
+
+async function playPhasedAnimation(
+  entry: MappingEntry,
+  controls: PlaybackControls,
+) {
+  const phases = entry.params.motionPhases;
+
+  if (phases === undefined || phases.length === 0) {
+    return;
+  }
+
+  await controls.stop();
+  await controls.set(getPhasedInitialTarget(entry));
+  await waitForNextFrame();
+  await wait(getPreviewChoreography(entry).holdInitialMs);
+
+  for (const phase of phases) {
+    await controls.start(getPhaseAnimation(entry, phase));
+  }
 }
 
 function getSingleStageAnimation(entry: MappingEntry): TargetAndTransition {
@@ -265,118 +413,6 @@ function getSingleStageAnimation(entry: MappingEntry): TargetAndTransition {
   return target;
 }
 
-async function playToastError(entry: MappingEntry, controls: PlaybackControls) {
-  const size = getPreviewSize(entry.component);
-  const transition = getTransition(entry);
-  const halfDuration = entry.params.duration / 2000;
-
-  await controls.stop();
-  await controls.set({
-    x: 0,
-    y: edgeToValue("bottom", size),
-    scale: 1,
-    opacity: entry.params.opacity?.[0] ?? 1,
-  });
-  await waitForNextFrame();
-
-  await controls.start({
-    y: 0,
-    opacity: entry.params.opacity?.[1] ?? 1,
-    transition: {
-      ...transition,
-      duration: halfDuration,
-    },
-  });
-
-  if (entry.params.keyframes !== undefined) {
-    await controls.start({
-      x: entry.params.keyframes.values,
-      transition: {
-        ...transition,
-        duration: halfDuration,
-        times: entry.params.keyframes.times,
-      },
-    });
-  }
-}
-
-async function playToastWarning(
-  entry: MappingEntry,
-  controls: PlaybackControls,
-) {
-  const size = getPreviewSize(entry.component);
-  const transition = getTransition(entry);
-  const enterDuration = (entry.params.duration * 0.62) / 1000;
-  const nudgeDuration = (entry.params.duration * 0.38) / 1000;
-
-  await controls.stop();
-  await controls.set({
-    x: 0,
-    y: edgeToValue("bottom", size),
-    scale: 1,
-    opacity: entry.params.opacity?.[0] ?? 1,
-  });
-  await waitForNextFrame();
-  await wait(entry.params.delay ?? 0);
-
-  await controls.start({
-    y: 0,
-    opacity: entry.params.opacity?.[1] ?? 1,
-    transition: {
-      ...transition,
-      delay: undefined,
-      duration: enterDuration,
-    },
-  });
-
-  await controls.start({
-    y: [0, -5, 0],
-    transition: {
-      ...transition,
-      delay: undefined,
-      duration: nudgeDuration,
-      times: [0, 0.5, 1],
-    },
-  });
-}
-
-async function playToastOneShot(
-  entry: MappingEntry,
-  controls: PlaybackControls,
-) {
-  const size = getPreviewSize(entry.component);
-  const transition = getTransition(entry);
-  const enterDuration = (entry.params.duration * 0.42) / 1000;
-  const pulseDuration = (entry.params.duration * 0.58) / 1000;
-
-  await controls.stop();
-  await controls.set({
-    x: 0,
-    y: edgeToValue("bottom", size),
-    scale: 1,
-    opacity: entry.params.opacity?.[0] ?? 1,
-  });
-  await waitForNextFrame();
-
-  await controls.start({
-    y: 0,
-    opacity: entry.params.opacity?.[1] ?? 1,
-    transition: {
-      ...transition,
-      duration: enterDuration,
-    },
-  });
-
-  await controls.start({
-    scale: [1, 1.025, 1, 1.025, 1],
-    transition: {
-      ...transition,
-      duration: pulseDuration,
-      times: [0, 0.25, 0.5, 0.75, 1],
-    },
-  });
-}
-
 async function playInputWarning(
   entry: MappingEntry,
   controls: PlaybackControls,
@@ -396,18 +432,8 @@ export async function playMappingAnimation(
   entry: MappingEntry,
   controls: PlaybackControls,
 ) {
-  if (entry.id === "toast-feedback-error") {
-    await playToastError(entry, controls);
-    return;
-  }
-
-  if (entry.id === "toast-feedback-warning") {
-    await playToastWarning(entry, controls);
-    return;
-  }
-
-  if (entry.id === "toast-attention-oneShot") {
-    await playToastOneShot(entry, controls);
+  if (entry.params.motionPhases !== undefined) {
+    await playPhasedAnimation(entry, controls);
     return;
   }
 

--- a/pocs/poc-04-export/README.md
+++ b/pocs/poc-04-export/README.md
@@ -22,7 +22,7 @@ Enthalten:
 - semantische Kommentare mit Bedeutung, Zeichentyp und Quelle
 - Sonderbehandlung für Spring-Easing im Framer-Motion-Export
 - CSS-Hinweis bei Spring-Mappings, weil CSS keine native Spring-Physik unterstützt
-- zweiphasiger Export für `toast-feedback-error`
+- generischer Export von `motionPhases` für mehrphasige Animationen
 
 Bewusst nicht enthalten:
 
@@ -117,5 +117,5 @@ Kein vollständiges Editor-UI. Der Export wird als isolierte Funktion validiert,
 - `generateExportBundle(entry)` gibt beide Exportvarianten gemeinsam zurück.
 - Framer Motion nutzt bei Spring-Mappings `transition.type = "spring"` und `springConfig`.
 - CSS nutzt bei Spring-Mappings eine kommentierte Approximation.
-- `toast-feedback-error` wird nicht als flacher `direction`/`keyframes`-Fall exportiert, sondern als zweiphasige Sequenz.
-- Tests validieren generellen Export, Button-Error-Keyframes, Spring-Export und Toast-Error-Sequenz.
+- Mehrphasige Mappings werden nicht als flache `direction`/`keyframes`-Fälle exportiert, sondern über `motionPhases`.
+- Tests validieren generellen Export, Button-Error-Keyframes, Spring-Export und mehrphasige Toast-Sequenzen.

--- a/pocs/poc-04-export/src/exportGenerators.test.ts
+++ b/pocs/poc-04-export/src/exportGenerators.test.ts
@@ -57,10 +57,10 @@ describe("POC 04 export generators", () => {
     const cssCode = generateCSSCode(entry!);
 
     expect(framerCode).toContain("async function toastFeedbackError");
-    expect(framerCode).toContain("erste Phase: y-Einfahrt");
-    expect(framerCode).toContain("zweite Phase: x-Shake");
+    expect(framerCode).toContain("Phase: enter");
+    expect(framerCode).toContain("Phase: shake");
     expect(cssCode).toContain("translateY(100%)");
-    expect(cssCode).toContain("translateY(0) translateX(-6px)");
+    expect(cssCode).toContain("translateX(-6px)");
   });
 
   it("exports toast warning as enter plus y nudge", () => {
@@ -72,10 +72,11 @@ describe("POC 04 export generators", () => {
     const cssCode = generateCSSCode(entry!);
 
     expect(framerCode).toContain("async function toastFeedbackWarning");
-    expect(framerCode).toContain("zweite Phase: moderater y-Nudge");
+    expect(framerCode).toContain("Phase: enter");
+    expect(framerCode).toContain("Phase: nudge");
     expect(framerCode).toContain("y: [0, -5, 0]");
     expect(cssCode).toContain(
-      "81% { opacity: 1; transform: translateY(-5px); }",
+      "84% { opacity: 1; transform: translateX(0) translateY(-5px) scale(1); }",
     );
   });
 
@@ -88,13 +89,14 @@ describe("POC 04 export generators", () => {
     const cssCode = generateCSSCode(entry!);
 
     expect(framerCode).toContain("async function toastAttentionOneShot");
+    expect(framerCode).toContain("Phase: enter");
+    expect(framerCode).toContain("Phase: pulse");
     expect(framerCode).toContain("scale: [1, 1.025, 1, 1.025, 1]");
-    expect(framerCode).toContain("zweite Phase: zwei subtile Scale-Impulse");
     expect(cssCode).toContain(
-      "56.5% { opacity: 1; transform: translateY(0) scale(1.025); }",
+      "56.5789% { opacity: 1; transform: translateX(0) translateY(0) scale(1.025); }",
     );
     expect(cssCode).toContain(
-      "85.5% { opacity: 1; transform: translateY(0) scale(1.025); }",
+      "85.5263% { opacity: 1; transform: translateX(0) translateY(0) scale(1.025); }",
     );
   });
 

--- a/pocs/poc-04-export/src/exportGenerators.ts
+++ b/pocs/poc-04-export/src/exportGenerators.ts
@@ -2,6 +2,7 @@ import {
   EASING_CURVES,
   type EasingValue,
   type MappingEntry,
+  type MotionPhase,
   type TranslationEdge,
 } from "../../../prototyp/src/framework/types";
 
@@ -49,6 +50,14 @@ function formatMotionArray(values: readonly (number | string)[]) {
     .join(", ")}]`;
 }
 
+function formatMotionValue(value: number | string | readonly number[]) {
+  if (Array.isArray(value)) {
+    return formatArray(value);
+  }
+
+  return typeof value === "string" ? `"${value}"` : String(value);
+}
+
 function formatPercent(value: number) {
   return Number(value.toFixed(4));
 }
@@ -93,6 +102,39 @@ function edgeToPercent(edge: TranslationEdge) {
     case "bottom":
       return "100%";
   }
+}
+
+function phaseAxis(phase: MotionPhase): Axis {
+  return phase.direction ?? "y";
+}
+
+function phaseEasing(entry: MappingEntry, phase: MotionPhase) {
+  return phase.easing ?? entry.params.easing;
+}
+
+function phaseSpringConfig(entry: MappingEntry, phase: MotionPhase) {
+  return phase.springConfig ?? entry.params.springConfig;
+}
+
+function phaseTimes(phase: MotionPhase) {
+  return (
+    phase.keyframes?.times ??
+    phase.scaleKeyframes?.times ??
+    phase.opacityKeyframes?.times
+  );
+}
+
+function phaseAnimationDuration(entry: MappingEntry) {
+  const phases = entry.params.motionPhases;
+
+  if (phases === undefined) {
+    return entry.params.duration;
+  }
+
+  return phases.reduce(
+    (sum, phase) => sum + phase.duration + (phase.delay ?? 0),
+    0,
+  );
 }
 
 function transformString(parts: TransformParts) {
@@ -180,102 +222,148 @@ function framerTransition(entry: MappingEntry, indent = "    ") {
     .join("\n");
 }
 
-function generateToastErrorFramerCode(entry: MappingEntry) {
-  const name = toCamelCase(entry.id);
-  const keyframes = entry.params.keyframes;
+function phaseInitialValues(entry: MappingEntry) {
+  const firstPhase = entry.params.motionPhases?.[0];
+  const initial = new Map<string, number | string>();
 
-  return `${sourceComment(entry, "//")}
+  initial.set("x", 0);
+  initial.set("y", 0);
+  initial.set("scale", 1);
+  initial.set("opacity", 1);
 
-export async function ${name}(controls) {
-  await controls.set({
-    x: 0,
-    y: "100%", // Einfahrt von unten
-    opacity: ${entry.params.opacity?.[0] ?? 1},
-  });
+  if (firstPhase === undefined) {
+    return initial;
+  }
 
-  await controls.start({
-    y: 0,
-    opacity: ${entry.params.opacity?.[1] ?? 1},
-    transition: {
-      duration: ${entry.params.duration / 2000}, // erste Phase: y-Einfahrt
-      ease: ${formatFramerEase(entry.params.easing)},
-    },
-  });
+  const axis = phaseAxis(firstPhase);
 
-  await controls.start({
-    x: ${formatArray(keyframes?.values ?? [0])}, // zweite Phase: x-Shake nach Ankunft
-    transition: {
-      duration: ${entry.params.duration / 2000},
-      ease: ${formatFramerEase(entry.params.easing)},
-      times: ${formatArray(keyframes?.times ?? [0])},
-    },
-  });
-}`;
+  if (firstPhase.opacity !== undefined) {
+    initial.set("opacity", firstPhase.opacity[0]);
+  }
+
+  if (firstPhase.opacityKeyframes !== undefined) {
+    initial.set("opacity", firstPhase.opacityKeyframes.values[0]);
+  }
+
+  if (firstPhase.scaleKeyframes !== undefined) {
+    initial.set("scale", firstPhase.scaleKeyframes.values[0]);
+  }
+
+  if (firstPhase.translateFrom !== undefined) {
+    initial.set(axis, edgeToPercent(firstPhase.translateFrom));
+  }
+
+  if (firstPhase.translateTo !== undefined) {
+    initial.set(axis, 0);
+  }
+
+  if (firstPhase.keyframes !== undefined) {
+    initial.set(axis, firstPhase.keyframes.values[0]);
+  }
+
+  return initial;
 }
 
-function generateToastWarningFramerCode(entry: MappingEntry) {
-  const name = toCamelCase(entry.id);
+function phaseAnimateValues(phase: MotionPhase) {
+  const animate = new Map<string, number | string | readonly number[]>();
+  const axis = phaseAxis(phase);
 
-  return `${sourceComment(entry, "//")}
+  if (phase.opacity !== undefined) {
+    animate.set("opacity", phase.opacity[1]);
+  }
 
-export async function ${name}(controls) {
-  await controls.set({
-    x: 0,
-    y: "100%", // Einfahrt von unten
-    opacity: ${entry.params.opacity?.[0] ?? 1},
-  });
+  if (phase.opacityKeyframes !== undefined) {
+    animate.set("opacity", phase.opacityKeyframes.values);
+  }
 
-  await controls.start({
-    y: 0,
-    opacity: ${entry.params.opacity?.[1] ?? 1},
-    transition: {
-      duration: ${(entry.params.duration * 0.62) / 1000}, // erste Phase: ruhige y-Einfahrt
-      delay: ${(entry.params.delay ?? 0) / 1000},
-      ease: ${formatFramerEase(entry.params.easing)},
-    },
-  });
+  if (phase.scaleKeyframes !== undefined) {
+    animate.set("scale", phase.scaleKeyframes.values);
+  }
 
-  await controls.start({
-    y: [0, -5, 0], // zweite Phase: moderater y-Nudge
-    transition: {
-      duration: ${(entry.params.duration * 0.38) / 1000},
-      ease: ${formatFramerEase(entry.params.easing)},
-      times: [0, 0.5, 1],
-    },
-  });
-}`;
+  if (phase.translateFrom !== undefined) {
+    animate.set(axis, 0);
+  }
+
+  if (phase.translateTo !== undefined) {
+    animate.set(axis, edgeToPercent(phase.translateTo));
+  }
+
+  if (phase.keyframes !== undefined) {
+    animate.set(axis, phase.keyframes.values);
+  }
+
+  if (phase.translatePx !== undefined) {
+    animate.set(axis, [0, phase.translatePx, 0]);
+  }
+
+  return animate;
 }
 
-function generateToastOneShotFramerCode(entry: MappingEntry) {
+function formatObjectLines(
+  values: Map<string, number | string | readonly number[]>,
+  indent = "    ",
+) {
+  return Array.from(values.entries())
+    .map(([key, value]) => `${indent}${key}: ${formatMotionValue(value)},`)
+    .join("\n");
+}
+
+function formatPhaseTransition(entry: MappingEntry, phase: MotionPhase) {
+  const easing = phaseEasing(entry, phase);
+  const times = phaseTimes(phase);
+
+  if ("preset" in easing && easing.preset === "spring") {
+    const springConfig = phaseSpringConfig(entry, phase);
+
+    return [
+      "      transition: {",
+      "        type: \"spring\",",
+      `        stiffness: ${springConfig?.stiffness ?? 100},`,
+      `        damping: ${springConfig?.damping ?? 10},`,
+      `        mass: ${springConfig?.mass ?? 1},`,
+      phase.delay !== undefined ? `        delay: ${phase.delay / 1000},` : null,
+      "      },",
+    ]
+      .filter(Boolean)
+      .join("\n");
+  }
+
+  return [
+    "      transition: {",
+    `        duration: ${phase.duration / 1000},`,
+    phase.delay !== undefined ? `        delay: ${phase.delay / 1000},` : null,
+    `        ease: ${formatFramerEase(easing)},`,
+    times !== undefined ? `        times: ${formatArray(times)},` : null,
+    "      },",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function generatePhasedFramerCode(entry: MappingEntry) {
   const name = toCamelCase(entry.id);
+  const phases = entry.params.motionPhases ?? [];
+  const initial = phaseInitialValues(entry);
+  const phaseBlocks = phases
+    .map((phase) => {
+      const animate = phaseAnimateValues(phase);
+
+      return `  // Phase: ${phase.id}
+  await controls.start({
+${formatObjectLines(animate, "    ")}
+${formatPhaseTransition(entry, phase)}
+  });`;
+    })
+    .join("\n\n");
 
   return `${sourceComment(entry, "//")}
 
 export async function ${name}(controls) {
   await controls.set({
-    x: 0,
-    y: "100%", // Einfahrt von unten
-    scale: 1,
-    opacity: ${entry.params.opacity?.[0] ?? 1},
+${formatObjectLines(initial)}
   });
 
-  await controls.start({
-    y: 0,
-    opacity: ${entry.params.opacity?.[1] ?? 1},
-    transition: {
-      duration: ${(entry.params.duration * 0.42) / 1000}, // erste Phase: ruhige y-Einfahrt
-      ease: ${formatFramerEase(entry.params.easing)},
-    },
-  });
-
-  await controls.start({
-    scale: [1, 1.025, 1, 1.025, 1], // zweite Phase: zwei subtile Scale-Impulse
-    transition: {
-      duration: ${(entry.params.duration * 0.58) / 1000},
-      ease: ${formatFramerEase(entry.params.easing)},
-      times: [0, 0.25, 0.5, 0.75, 1],
-    },
-  });
+${phaseBlocks}
 }`;
 }
 
@@ -393,16 +481,8 @@ export const ${name} = {
 }
 
 export function generateFramerMotionCode(entry: MappingEntry): string {
-  if (entry.id === "toast-feedback-error") {
-    return generateToastErrorFramerCode(entry);
-  }
-
-  if (entry.id === "toast-feedback-warning") {
-    return generateToastWarningFramerCode(entry);
-  }
-
-  if (entry.id === "toast-attention-oneShot") {
-    return generateToastOneShotFramerCode(entry);
+  if (entry.params.motionPhases !== undefined) {
+    return generatePhasedFramerCode(entry);
   }
 
   if (entry.id === "input-feedback-warning") {
@@ -518,44 +598,157 @@ ${framerTransition(entry, "  ")}
 };`;
 }
 
+type CssPhaseState = {
+  x: string;
+  y: string;
+  scale: string;
+  opacity: number;
+};
+
+type CssFrame = {
+  time: number;
+  state: CssPhaseState;
+};
+
+function cloneCssState(state: CssPhaseState): CssPhaseState {
+  return { ...state };
+}
+
+function cssTransformFromState(state: CssPhaseState) {
+  return transformString({
+    x: state.x,
+    y: state.y,
+    scale: state.scale,
+  });
+}
+
+function cssFrameLine(frame: CssFrame, totalDuration: number) {
+  const percent = totalDuration === 0 ? 100 : formatPercent((frame.time / totalDuration) * 100);
+
+  return `  ${percent}% { opacity: ${frame.state.opacity}; transform: ${cssTransformFromState(frame.state)}; }`;
+}
+
+function getInitialCssPhaseState(entry: MappingEntry): CssPhaseState {
+  const state: CssPhaseState = {
+    x: "0",
+    y: "0",
+    scale: "1",
+    opacity: 1,
+  };
+  const firstPhase = entry.params.motionPhases?.[0];
+
+  if (firstPhase === undefined) {
+    return state;
+  }
+
+  const axis = phaseAxis(firstPhase);
+
+  if (firstPhase.opacity !== undefined) {
+    state.opacity = firstPhase.opacity[0];
+  }
+
+  if (firstPhase.opacityKeyframes !== undefined) {
+    state.opacity = firstPhase.opacityKeyframes.values[0];
+  }
+
+  if (firstPhase.scaleKeyframes !== undefined) {
+    state.scale = String(firstPhase.scaleKeyframes.values[0]);
+  }
+
+  if (firstPhase.translateFrom !== undefined) {
+    state[axis] = edgeToPercent(firstPhase.translateFrom);
+  }
+
+  if (firstPhase.translateTo !== undefined) {
+    state[axis] = "0";
+  }
+
+  if (firstPhase.keyframes !== undefined) {
+    state[axis] = `${firstPhase.keyframes.values[0]}px`;
+  }
+
+  return state;
+}
+
+function generatePhasedCssKeyframes(entry: MappingEntry) {
+  const phases = entry.params.motionPhases ?? [];
+  const keyframesName = `smf-${entry.id}`;
+  const totalDuration = phaseAnimationDuration(entry);
+  const frames: CssFrame[] = [];
+  const state = getInitialCssPhaseState(entry);
+  let currentTime = 0;
+
+  frames.push({ time: currentTime, state: cloneCssState(state) });
+
+  for (const phase of phases) {
+    const axis = phaseAxis(phase);
+
+    if (phase.delay !== undefined && phase.delay > 0) {
+      currentTime += phase.delay;
+      frames.push({ time: currentTime, state: cloneCssState(state) });
+    }
+
+    if (phase.opacity !== undefined) {
+      state.opacity = phase.opacity[1];
+    }
+
+    if (phase.translateFrom !== undefined) {
+      state[axis] = "0";
+    }
+
+    if (phase.translateTo !== undefined) {
+      state[axis] = edgeToPercent(phase.translateTo);
+    }
+
+    if (
+      phase.keyframes === undefined &&
+      phase.scaleKeyframes === undefined &&
+      phase.opacityKeyframes === undefined
+    ) {
+      frames.push({
+        time: currentTime + phase.duration,
+        state: cloneCssState(state),
+      });
+      currentTime += phase.duration;
+      continue;
+    }
+
+    const times = phaseTimes(phase) ?? [0, 1];
+
+    for (const [index, time] of times.entries()) {
+      if (phase.keyframes !== undefined) {
+        state[axis] = `${phase.keyframes.values[index]}px`;
+      }
+
+      if (phase.scaleKeyframes !== undefined) {
+        state.scale = String(phase.scaleKeyframes.values[index]);
+      }
+
+      if (phase.opacityKeyframes !== undefined) {
+        state.opacity = phase.opacityKeyframes.values[index];
+      }
+
+      frames.push({
+        time: currentTime + time * phase.duration,
+        state: cloneCssState(state),
+      });
+    }
+
+    currentTime += phase.duration;
+  }
+
+  return `@keyframes ${keyframesName} {
+${frames.map((frame) => cssFrameLine(frame, totalDuration)).join("\n")}
+}`;
+}
+
 function cssKeyframes(entry: MappingEntry) {
   const { params } = entry;
   const axis = getAxis(entry);
   const keyframesName = `smf-${entry.id}`;
 
-  if (entry.id === "toast-feedback-error" && params.keyframes !== undefined) {
-    const shakeFrames = params.keyframes.values
-      .map((value, index) => {
-        const percent = formatPercent(50 + params.keyframes!.times[index] * 50);
-        return `  ${percent}% { opacity: 1; transform: translateY(0) translateX(${value}px); }`;
-      })
-      .join("\n");
-
-    return `@keyframes ${keyframesName} {
-  0% { opacity: ${params.opacity?.[0] ?? 1}; transform: translateY(100%) translateX(0); }
-  50% { opacity: ${params.opacity?.[1] ?? 1}; transform: translateY(0) translateX(0); }
-${shakeFrames}
-}`;
-  }
-
-  if (entry.id === "toast-feedback-warning") {
-    return `@keyframes ${keyframesName} {
-  0% { opacity: ${params.opacity?.[0] ?? 1}; transform: translateY(100%); }
-  62% { opacity: ${params.opacity?.[1] ?? 1}; transform: translateY(0); }
-  81% { opacity: ${params.opacity?.[1] ?? 1}; transform: translateY(-5px); }
-  100% { opacity: ${params.opacity?.[1] ?? 1}; transform: translateY(0); }
-}`;
-  }
-
-  if (entry.id === "toast-attention-oneShot") {
-    return `@keyframes ${keyframesName} {
-  0% { opacity: ${params.opacity?.[0] ?? 1}; transform: translateY(100%) scale(1); }
-  42% { opacity: ${params.opacity?.[1] ?? 1}; transform: translateY(0) scale(1); }
-  56.5% { opacity: ${params.opacity?.[1] ?? 1}; transform: translateY(0) scale(1.025); }
-  71% { opacity: ${params.opacity?.[1] ?? 1}; transform: translateY(0) scale(1); }
-  85.5% { opacity: ${params.opacity?.[1] ?? 1}; transform: translateY(0) scale(1.025); }
-  100% { opacity: ${params.opacity?.[1] ?? 1}; transform: translateY(0) scale(1); }
-}`;
+  if (params.motionPhases !== undefined) {
+    return generatePhasedCssKeyframes(entry);
   }
 
   if (params.opacityKeyframes !== undefined) {
@@ -740,7 +933,7 @@ ${warning}
 ${cssKeyframes(entry)}
 
 .${className} {
-  animation: smf-${entry.id} ${entry.params.duration}ms ${formatCssEase(entry.params.easing)} both;
+  animation: smf-${entry.id} ${phaseAnimationDuration(entry)}ms ${formatCssEase(entry.params.easing)} both;
 }`;
 }
 

--- a/prototyp/src/data/mappings.ts
+++ b/prototyp/src/data/mappings.ts
@@ -233,19 +233,26 @@ export const mappings: MappingDatabase = [
     params: {
       easing: { preset: "sharp" },
       duration: 320,
-      direction: "y",
-      translateDistance: "self",
-      translateFrom: "bottom",
       iterations: 1,
-      opacity: [0, 1],
-      keyframes: {
-        // Shake auf der x-Achse nach Einfahrt auf der y-Achse;
-        // zweiphasige Animation: Phase 1 = y-Einfahrt, Phase 2 = x-Shake
-        // Aktuell als gezielter Renderer-Sonderfall umgesetzt;
-        // späterer Kandidat für ein generisches motionPhases-Modell.
-        values: [0, -6, 6, -6, 6, 0],
-        times:  [0, 0.2, 0.4, 0.6, 0.8, 1.0],
-      },
+      motionPhases: [
+        {
+          id: "enter",
+          duration: 160,
+          direction: "y",
+          translateDistance: "self",
+          translateFrom: "bottom",
+          opacity: [0, 1],
+        },
+        {
+          id: "shake",
+          duration: 160,
+          direction: "x",
+          keyframes: {
+            values: [0, -6, 6, -6, 6, 0],
+            times:  [0, 0.2, 0.4, 0.6, 0.8, 1.0],
+          },
+        },
+      ],
     },
     rationale: {
       short:
@@ -271,15 +278,27 @@ export const mappings: MappingDatabase = [
     params: {
       easing: { preset: "easeInOut" },
       duration: 420,
-      delay: 80,
-      direction: "y",
-      translateDistance: "self",
-      translateFrom: "bottom",
       iterations: 1,
-      opacity: [0, 1],
-      // Mehrphasige Animation: y-Einfahrt plus sekundärer y-Nudge.
-      // Aktuell als gezielter Renderer-Sonderfall umgesetzt;
-      // späterer Kandidat für ein generisches motionPhases-Modell.
+      motionPhases: [
+        {
+          id: "enter",
+          delay: 80,
+          duration: 260,
+          direction: "y",
+          translateDistance: "self",
+          translateFrom: "bottom",
+          opacity: [0, 1],
+        },
+        {
+          id: "nudge",
+          duration: 160,
+          direction: "y",
+          keyframes: {
+            values: [0, -5, 0],
+            times: [0, 0.5, 1],
+          },
+        },
+      ],
     },
     rationale: {
       short:
@@ -306,14 +325,25 @@ export const mappings: MappingDatabase = [
     params: {
       easing: { preset: "easeOut" },
       duration: 760,
-      direction: "y",
-      translateDistance: "self",
-      translateFrom: "bottom",
       iterations: 1,
-      opacity: [0, 1],
-      // Mehrphasige Animation: y-Einfahrt plus sekundäre Scale-Impulse.
-      // Aktuell als gezielter Renderer-Sonderfall umgesetzt;
-      // späterer Kandidat für ein generisches motionPhases-Modell.
+      motionPhases: [
+        {
+          id: "enter",
+          duration: 320,
+          direction: "y",
+          translateDistance: "self",
+          translateFrom: "bottom",
+          opacity: [0, 1],
+        },
+        {
+          id: "pulse",
+          duration: 440,
+          scaleKeyframes: {
+            values: [1, 1.025, 1, 1.025, 1],
+            times: [0, 0.25, 0.5, 0.75, 1],
+          },
+        },
+      ],
     },
     rationale: {
       short:

--- a/prototyp/src/framework/types.ts
+++ b/prototyp/src/framework/types.ts
@@ -201,6 +201,63 @@ export interface KeyframeSequence {
 }
 
 /**
+ * Eine explizite Phase innerhalb einer mehrphasigen Animation.
+ * Jede Phase beschreibt genau einen sequenziellen Bewegungsschritt
+ * auf demselben animierten Hauptelement, z. B. erst Einfahrt, danach Shake.
+ *
+ * Phasen verwenden standardmäßig easing aus AnimationParams. Ein eigenes
+ * easing kann gesetzt werden, wenn eine Phase bewusst eine andere Kurve braucht.
+ * duration ist phasenspezifisch und wird in Millisekunden angegeben.
+ */
+export interface MotionPhase {
+  /** Maschinenlesbarer Phasenname, z. B. "enter", "shake", "nudge" */
+  id: string;
+
+  /** Dauer dieser Phase in Millisekunden */
+  duration: number;
+
+  /** Optionale Verzögerung vor dieser Phase in Millisekunden */
+  delay?: number;
+
+  /** Optionale eigene Beschleunigungskurve; sonst gilt AnimationParams.easing */
+  easing?: EasingValue;
+
+  /**
+   * Semantisch relevante Achse der translatorischen Bewegung dieser Phase.
+   * Erforderlich wenn translatePx, translateDistance, translateFrom,
+   * translateTo oder keyframes gesetzt ist.
+   */
+  direction?: "x" | "y";
+
+  /** Pixel-Versatz für translatorische Phasen */
+  translatePx?: number;
+
+  /** Größenabhängige Translationsdistanz dieser Phase */
+  translateDistance?: TranslationDistance;
+
+  /** Startkante einer größenabhängigen Enter-Phase */
+  translateFrom?: TranslationEdge;
+
+  /** Zielkante einer größenabhängigen Exit-Phase */
+  translateTo?: TranslationEdge;
+
+  /** Explizite translatorische Keyframes dieser Phase */
+  keyframes?: KeyframeSequence;
+
+  /** Explizite Scale-Keyframes dieser Phase */
+  scaleKeyframes?: KeyframeSequence;
+
+  /** Deckkraft-Bereich [von, bis] dieser Phase */
+  opacity?: [number, number];
+
+  /** Explizite Deckkraft-Keyframes dieser Phase */
+  opacityKeyframes?: KeyframeSequence;
+
+  /** Federmechanik-Konfiguration, falls diese Phase spring verwendet */
+  springConfig?: SpringConfig;
+}
+
+/**
  * Kante, von der eine größenabhängige Translation startet oder zu der sie führt.
  * Wird nur für Enter-/Exit-Bewegungen verwendet, bei denen der konkrete Pixelwert
  * erst im Komponenten-Rendering bekannt ist.
@@ -248,6 +305,11 @@ export type TranslationDistance = "self";
  * sondern ein ergänzender Sichtbarkeitsparameter. Sie darf ergänzend oder alleine
  * verwendet werden, muss dann aber semantisch als Erscheinen, Verschwinden,
  * Abschluss, Fokusverlust oder Verfügbarkeit begründet sein.
+ *
+ * Mehrphasige Animationen werden über motionPhases modelliert. In diesem Fall
+ * bleiben die flachen Bewegungsfelder auf AnimationParams frei; die konkrete
+ * Bewegung liegt in den einzelnen Phasen. easing und duration bleiben auf
+ * oberster Ebene als Default-Kurve und Gesamtdauer lesbar.
  */
 export interface AnimationParams {
   /** Beschleunigungskurve – der semantisch bedeutsamste Parameter */
@@ -357,6 +419,16 @@ export interface AnimationParams {
    * Wenn vorhanden, präzisiert dieses Feld den einfachen opacity-Bereich.
    */
   opacityKeyframes?: KeyframeSequence;
+
+  /**
+   * Sequenz expliziter Bewegungsphasen für mehrphasige Animationen.
+   * Wird verwendet, wenn eine einzelne flache Parametergruppe die semantische
+   * Bewegung nicht sauber abbilden kann, z. B. Toast-Einfahrt plus Shake.
+   *
+   * Wenn motionPhases vorhanden ist, behandeln Preview und Export diese Phasen
+   * als primäre Bewegungsbeschreibung.
+   */
+  motionPhases?: MotionPhase[];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Add a generic motionPhases model to AnimationParams and use it for the multi-step Toast mappings. Replace the previous Toast-specific preview and export special cases with generic phase handling in POC 03 and POC 04.

Extend mapping validation to cover phase structure, keyframes, direction rules, and mixing with flat motion fields. Document the architecture decision as ADR-10 and update TODO/POC documentation to reflect the new phase model.