### PR TITLE
feat: stabilize responsive editor layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ docs/framework-evaluation.md
 docs/poc-03-mapping-evaluation.md
 docs/editor-mapping-review.md
 docs/wissenschaftliche-ausarbeitung-notizen.md
+docs/professor-feedback-research-diary-02.md
 docs/prototyp-page-todos.md
 
 # Local mockups

--- a/prototyp/src/App.css
+++ b/prototyp/src/App.css
@@ -1056,7 +1056,11 @@
   margin-top: 1rem;
 }
 
-.editor-option-group > span {
+.editor-option-summary {
+  display: none;
+}
+
+.editor-option-label {
   display: block;
   margin-bottom: 0.4rem;
   color: var(--ink);
@@ -1064,13 +1068,13 @@
   font-weight: 500;
 }
 
-.editor-option-group > div {
+.editor-option-list {
   display: grid;
   grid-template-columns: 1fr;
   gap: 0.32rem;
 }
 
-.editor-option-group button {
+.editor-option-list button {
   display: flex;
   min-height: 2rem;
   width: 100%;
@@ -1091,13 +1095,13 @@
     opacity 180ms ease;
 }
 
-.editor-option-group button:hover:not(:disabled) {
+.editor-option-list button:hover:not(:disabled) {
   border-color: rgba(17, 24, 39, 0.22);
   background: var(--soft);
   color: var(--ink);
 }
 
-.editor-option-group button.selected {
+.editor-option-list button.selected {
   border-color: rgba(240, 45, 0, 0.34);
   background: rgba(240, 45, 0, 0.06);
   box-shadow: inset 3px 0 0 var(--red);
@@ -1105,7 +1109,7 @@
   font-weight: 500;
 }
 
-.editor-option-group button:disabled {
+.editor-option-list button:disabled {
   cursor: not-allowed;
   opacity: 0.32;
 }
@@ -1522,10 +1526,15 @@
 
 .editor-source-tooltip-trigger:hover + .editor-source-tooltip,
 .editor-source-tooltip-trigger:focus-visible + .editor-source-tooltip,
+.editor-source-tooltip-wrap.is-open .editor-source-tooltip,
 .editor-source-tooltip:hover {
   opacity: 1;
   pointer-events: auto;
   transform: translateY(0);
+}
+
+.editor-source-mobile-panel {
+  display: none;
 }
 
 .editor-sign-group {
@@ -1663,12 +1672,26 @@
   }
 
   .editor-grid {
+    height: auto;
+    min-height: calc(100vh - 39px);
     grid-template-columns: minmax(210px, 0.7fr) minmax(0, 1fr);
+    overflow: visible;
+  }
+
+  .editor-page {
+    height: auto;
+    min-height: calc(100vh - 39px);
+    overflow: visible;
   }
 
   .editor-detail-column {
     grid-column: 1 / -1;
     border-top: 0.5px solid var(--border);
+    overflow: visible;
+  }
+
+  .editor-export-panel {
+    min-height: 26rem;
   }
 }
 
@@ -1783,6 +1806,7 @@
   }
 
   .editor-grid {
+    min-height: 0;
     grid-template-columns: 1fr;
   }
 
@@ -1798,6 +1822,138 @@
   .editor-export-panel {
     padding-right: 1.25rem;
     padding-left: 1.25rem;
+  }
+
+  .editor-selection-panel {
+    gap: 0.55rem;
+  }
+
+  .editor-option-group {
+    margin-top: 0;
+    border: 0.5px solid var(--border);
+  }
+
+  .editor-option-label {
+    display: none;
+  }
+
+  .editor-option-summary {
+    display: grid;
+    width: 100%;
+    grid-template-columns: minmax(0, 0.55fr) minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 0.75rem;
+    border: 0;
+    background: transparent;
+    color: var(--ink);
+    font-family: inherit;
+    padding: 0.72rem 0.8rem;
+    text-align: left;
+  }
+
+  .editor-option-summary::after {
+    content: "+";
+    color: var(--red);
+    font-size: 0.875rem;
+    font-weight: 400;
+    line-height: 1;
+  }
+
+  .editor-option-group.mobile-open .editor-option-summary::after {
+    content: "-";
+  }
+
+  .editor-option-summary:hover,
+  .editor-option-summary:focus-visible {
+    background: var(--softer);
+  }
+
+  .editor-option-summary span {
+    color: var(--muted);
+    font-size: 0.5625rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .editor-option-summary strong {
+    overflow: hidden;
+    font-size: 0.75rem;
+    font-weight: 500;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .editor-option-list {
+    display: grid;
+    max-height: 0;
+    overflow: hidden;
+    opacity: 0;
+    gap: 0.38rem;
+    border-top: 0.5px solid transparent;
+    padding: 0 0.55rem;
+    pointer-events: none;
+    transition:
+      max-height 260ms cubic-bezier(0.4, 0, 0.2, 1),
+      opacity 180ms ease,
+      padding 260ms cubic-bezier(0.4, 0, 0.2, 1),
+      border-color 180ms ease;
+  }
+
+  .editor-option-group.mobile-open .editor-option-list {
+    max-height: 18rem;
+    opacity: 1;
+    border-top-color: var(--border);
+    padding: 0.55rem;
+    pointer-events: auto;
+  }
+
+  .editor-metadata {
+    margin-top: 0.2rem;
+  }
+
+  .editor-stage {
+    height: clamp(14rem, 56vw, 18rem);
+    min-height: 14rem;
+    padding: 1.4rem;
+  }
+
+  .editor-detail-column {
+    border-top: 0;
+  }
+
+  .editor-export-panel {
+    min-height: 24rem;
+  }
+
+  .editor-source-tooltip {
+    display: none;
+  }
+
+  .editor-source-mobile-panel {
+    display: block;
+    max-height: 0;
+    overflow: hidden;
+    border: 0.5px solid transparent;
+    color: rgba(17, 24, 39, 0.68);
+    font-size: 0.6875rem;
+    line-height: 1.55;
+    opacity: 0;
+    padding: 0 0.85rem;
+    transition:
+      max-height 260ms cubic-bezier(0.4, 0, 0.2, 1),
+      opacity 180ms ease,
+      padding 260ms cubic-bezier(0.4, 0, 0.2, 1),
+      border-color 180ms ease,
+      margin-top 260ms cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  .editor-source-mobile-panel.is-open {
+    max-height: 18rem;
+    overflow: auto;
+    border-color: rgba(240, 45, 0, 0.28);
+    opacity: 1;
+    padding: 0.85rem;
+    margin-top: 0.2rem;
   }
 }
 
@@ -1837,5 +1993,29 @@
   .editor-parameter-grid,
   .about-meta {
     grid-template-columns: 1fr;
+  }
+
+  .editor-stage {
+    height: 13rem;
+    min-height: 13rem;
+    margin: 0.75rem 0;
+    padding: 1rem;
+  }
+
+  .editor-preview-toast,
+  .editor-preview-modal,
+  .editor-preview-input,
+  .editor-preview-skeleton {
+    width: 100%;
+  }
+
+  .editor-export-tabs,
+  .editor-export-actions,
+  .editor-sign-group {
+    flex-wrap: wrap;
+  }
+
+  .editor-export-panel pre {
+    max-height: 18rem;
   }
 }

--- a/prototyp/src/pages/Editor.tsx
+++ b/prototyp/src/pages/Editor.tsx
@@ -41,6 +41,8 @@ type EditorProps = {
   onSelectionChange: (selection: EditorSelection) => void;
 };
 
+type MobilePicker = 'component' | 'dimension' | 'subcategory';
+
 function getFirstDimension(component: ComponentId) {
   return getDimensionsForComponent(component)[0] ?? 'feedback';
 }
@@ -93,6 +95,10 @@ export const defaultEditorSelection: EditorSelection = {
 function Editor({ selection, onSelectionChange }: EditorProps) {
   const [replayKey, setReplayKey] = useState(0);
   const [isReplayCoolingDown, setIsReplayCoolingDown] = useState(false);
+  const [isSourceTooltipOpen, setIsSourceTooltipOpen] = useState(false);
+  const [isMobileViewport, setIsMobileViewport] = useState(false);
+  const [openMobilePicker, setOpenMobilePicker] =
+    useState<MobilePicker | null>(null);
   const replayCooldownRef = useRef<number | null>(null);
   const { component, dimension, subcategory } = selection;
 
@@ -113,10 +119,24 @@ function Editor({ selection, onSelectionChange }: EditorProps) {
 
   useEffect(() => {
     setIsReplayCoolingDown(false);
+    setIsSourceTooltipOpen(false);
     clearReplayCooldown();
 
     return clearReplayCooldown;
   }, [entry?.id]);
+
+  useEffect(() => {
+    const query = window.matchMedia('(max-width: 820px)');
+    const updateViewportMode = () => {
+      setIsMobileViewport(query.matches);
+      setIsSourceTooltipOpen(false);
+    };
+
+    updateViewportMode();
+    query.addEventListener('change', updateViewportMode);
+
+    return () => query.removeEventListener('change', updateViewportMode);
+  }, []);
 
   if (!entry) {
     return <main className="main-content empty-page" />;
@@ -145,6 +165,7 @@ function Editor({ selection, onSelectionChange }: EditorProps) {
       dimension: nextDimension,
       subcategory: nextSubcategory,
     });
+    setOpenMobilePicker(null);
   };
 
   const selectDimension = (nextDimension: Dimension) => {
@@ -157,6 +178,7 @@ function Editor({ selection, onSelectionChange }: EditorProps) {
       dimension: nextDimension,
       subcategory: getFirstSubcategory(component, nextDimension),
     });
+    setOpenMobilePicker(null);
   };
 
   const selectSubcategory = (nextSubcategory: Subcategory) => {
@@ -169,6 +191,11 @@ function Editor({ selection, onSelectionChange }: EditorProps) {
       dimension,
       subcategory: nextSubcategory,
     });
+    setOpenMobilePicker(null);
+  };
+
+  const toggleMobilePicker = (picker: MobilePicker) => {
+    setOpenMobilePicker((current) => (current === picker ? null : picker));
   };
 
   return (
@@ -177,9 +204,24 @@ function Editor({ selection, onSelectionChange }: EditorProps) {
         <aside className="editor-panel editor-selection-panel">
           <p className="editor-panel-title">Auswahl</p>
 
-          <div className="editor-option-group">
-            <span>Komponente</span>
-            <div>
+          <div
+            className={[
+              'editor-option-group',
+              openMobilePicker === 'component' ? 'mobile-open' : '',
+            ].join(' ')}
+          >
+            <button
+              aria-controls="editor-component-options"
+              aria-expanded={openMobilePicker === 'component'}
+              className="editor-option-summary"
+              onClick={() => toggleMobilePicker('component')}
+              type="button"
+            >
+              <span>Komponente</span>
+              <strong>{componentLabels[component]}</strong>
+            </button>
+            <span className="editor-option-label">Komponente</span>
+            <div className="editor-option-list" id="editor-component-options">
               {getDefinedComponents().map((item) => (
                 <MotionActionButton
                   className={component === item ? 'selected' : ''}
@@ -193,9 +235,24 @@ function Editor({ selection, onSelectionChange }: EditorProps) {
             </div>
           </div>
 
-          <div className="editor-option-group">
-            <span>Dimension</span>
-            <div>
+          <div
+            className={[
+              'editor-option-group',
+              openMobilePicker === 'dimension' ? 'mobile-open' : '',
+            ].join(' ')}
+          >
+            <button
+              aria-controls="editor-dimension-options"
+              aria-expanded={openMobilePicker === 'dimension'}
+              className="editor-option-summary"
+              onClick={() => toggleMobilePicker('dimension')}
+              type="button"
+            >
+              <span>Dimension</span>
+              <strong>{dimensionLabels[dimension]}</strong>
+            </button>
+            <span className="editor-option-label">Dimension</span>
+            <div className="editor-option-list" id="editor-dimension-options">
               {getDefinedDimensions().map((item) => {
                 const isAvailable =
                   getMappingsForDimension(component, item).length > 0;
@@ -215,9 +272,24 @@ function Editor({ selection, onSelectionChange }: EditorProps) {
             </div>
           </div>
 
-          <div className="editor-option-group">
-            <span>Subkategorie</span>
-            <div>
+          <div
+            className={[
+              'editor-option-group',
+              openMobilePicker === 'subcategory' ? 'mobile-open' : '',
+            ].join(' ')}
+          >
+            <button
+              aria-controls="editor-subcategory-options"
+              aria-expanded={openMobilePicker === 'subcategory'}
+              className="editor-option-summary"
+              onClick={() => toggleMobilePicker('subcategory')}
+              type="button"
+            >
+              <span>Subkategorie</span>
+              <strong>{subcategoryLabels[subcategory]}</strong>
+            </button>
+            <span className="editor-option-label">Subkategorie</span>
+            <div className="editor-option-list" id="editor-subcategory-options">
               {getDefinedSubcategoriesForDimension(dimension).map((item) => {
                 const isAvailable = isSupportedCombination(
                   component,
@@ -307,10 +379,23 @@ function Editor({ selection, onSelectionChange }: EditorProps) {
                 >
                   {signTypeLabels[entry.rationale.signType]}
                 </span>
-                <div className="editor-source-tooltip-wrap">
+                <div
+                  className={[
+                    'editor-source-tooltip-wrap',
+                    isSourceTooltipOpen ? 'is-open' : '',
+                  ].join(' ')}
+                >
                   <MotionActionButton
+                    aria-controls="editor-source-mobile-panel"
+                    aria-expanded={isSourceTooltipOpen}
                     aria-label="Theoretische Begründung anzeigen"
                     className="editor-source-tooltip-trigger"
+                    onClick={() => {
+                      if (isMobileViewport) {
+                        setIsSourceTooltipOpen((current) => !current);
+                      }
+                    }}
+                    successFeedback={false}
                     type="button"
                   >
                     ?
@@ -322,6 +407,15 @@ function Editor({ selection, onSelectionChange }: EditorProps) {
               </div>
             </div>
             <p>{entry.rationale.short}</p>
+            <div
+              className={[
+                'editor-source-mobile-panel',
+                isSourceTooltipOpen ? 'is-open' : '',
+              ].join(' ')}
+              id="editor-source-mobile-panel"
+            >
+              {entry.rationale.source}
+            </div>
 
             <div className="editor-sign-group">
               {(['icon', 'index', 'symbol'] as const).map((signType) => (


### PR DESCRIPTION
Keep the desktop editor viewport-fixed while allowing tablet and mobile layouts to scroll safely.

Add a compact mobile accordion for component, dimension and subcategory selection.

Adjust rationale source handling so desktop keeps hover behavior and mobile uses a tap-open inline panel.

Ignore local professor feedback notes.