### PR TITLE
feat: add semantic context layer to framework and editor

### DIFF
--- a/prototyp/package-lock.json
+++ b/prototyp/package-lock.json
@@ -24,7 +24,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.26",
         "globals": "^16.5.0",
-        "prettier": "^3.7.4",
+        "prettier": "^3.8.4",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.53.0",
         "vite": "^7.2.4",
@@ -32,13 +32,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.28.6.tgz",
-      "integrity": "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.6.tgz",
-      "integrity": "sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -57,21 +57,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
-      "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/generator": "^7.28.6",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -88,14 +88,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.6.tgz",
-      "integrity": "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -105,14 +105,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -122,9 +122,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -132,29 +132,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -174,9 +174,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -184,9 +184,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -194,9 +194,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -204,27 +204,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
-      "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.6"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -266,33 +266,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.6.tgz",
-      "integrity": "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/generator": "^7.28.6",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.6",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -300,23 +300,23 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz",
-      "integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
-      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
@@ -331,9 +331,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
-      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
@@ -348,9 +348,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
-      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
@@ -365,9 +365,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
-      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
@@ -382,9 +382,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
-      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -399,9 +399,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
-      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
@@ -416,9 +416,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
@@ -433,9 +433,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
-      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
@@ -450,9 +450,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
-      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
@@ -467,9 +467,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
-      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
@@ -484,9 +484,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
-      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
@@ -501,9 +501,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
-      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
@@ -518,9 +518,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
-      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
@@ -535,9 +535,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
-      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
@@ -552,9 +552,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
-      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
@@ -569,9 +569,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
-      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
@@ -586,9 +586,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
-      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -603,9 +603,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
@@ -620,9 +620,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
-      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
@@ -637,9 +637,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
@@ -654,9 +654,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
-      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
@@ -671,9 +671,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
-      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
       "cpu": [
         "arm64"
       ],
@@ -688,9 +688,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
-      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
@@ -705,9 +705,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
-      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
@@ -722,9 +722,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
-      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
@@ -739,9 +739,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
-      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],
@@ -1015,9 +1015,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.53",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.53.tgz",
-      "integrity": "sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==",
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -1748,16 +1748,16 @@
       }
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.2.tgz",
-      "integrity": "sha512-EcA07pHJouywpzsoTUqNh5NwGayl2PPVEJKUSinGGSxFGYn+shYbqMGBg6FXDqgXum9Ou/ecb+411ssw8HImJQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.28.5",
+        "@babel/core": "^7.29.0",
         "@babel/plugin-transform-react-jsx-self": "^7.27.1",
         "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-beta.53",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
         "@types/babel__core": "^7.20.5",
         "react-refresh": "^0.18.0"
       },
@@ -1765,7 +1765,7 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -2128,13 +2128,16 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.14",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.14.tgz",
-      "integrity": "sha512-B0xUquLkiGLgHhpPBqvl7GWegWBUNuujQ6kXd/r1U38ElPT6Ok8KZ8e+FpUGEc2ZoRQUzq/aUnaKFc/svWUGSg==",
+      "version": "2.10.37",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
+      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -2149,9 +2152,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -2169,11 +2172,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2253,9 +2256,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001764",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001764.tgz",
-      "integrity": "sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -2527,9 +2530,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.267",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
-      "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
+      "version": "1.5.372",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.372.tgz",
+      "integrity": "sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2718,9 +2721,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
-      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2731,32 +2734,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.2",
-        "@esbuild/android-arm": "0.27.2",
-        "@esbuild/android-arm64": "0.27.2",
-        "@esbuild/android-x64": "0.27.2",
-        "@esbuild/darwin-arm64": "0.27.2",
-        "@esbuild/darwin-x64": "0.27.2",
-        "@esbuild/freebsd-arm64": "0.27.2",
-        "@esbuild/freebsd-x64": "0.27.2",
-        "@esbuild/linux-arm": "0.27.2",
-        "@esbuild/linux-arm64": "0.27.2",
-        "@esbuild/linux-ia32": "0.27.2",
-        "@esbuild/linux-loong64": "0.27.2",
-        "@esbuild/linux-mips64el": "0.27.2",
-        "@esbuild/linux-ppc64": "0.27.2",
-        "@esbuild/linux-riscv64": "0.27.2",
-        "@esbuild/linux-s390x": "0.27.2",
-        "@esbuild/linux-x64": "0.27.2",
-        "@esbuild/netbsd-arm64": "0.27.2",
-        "@esbuild/netbsd-x64": "0.27.2",
-        "@esbuild/openbsd-arm64": "0.27.2",
-        "@esbuild/openbsd-x64": "0.27.2",
-        "@esbuild/openharmony-arm64": "0.27.2",
-        "@esbuild/sunos-x64": "0.27.2",
-        "@esbuild/win32-arm64": "0.27.2",
-        "@esbuild/win32-ia32": "0.27.2",
-        "@esbuild/win32-x64": "0.27.2"
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escalade": {
@@ -4176,11 +4179,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -4485,9 +4491,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
-      "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5375,9 +5381,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/prototyp/package.json
+++ b/prototyp/package.json
@@ -31,7 +31,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.26",
     "globals": "^16.5.0",
-    "prettier": "^3.7.4",
+    "prettier": "^3.8.4",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.53.0",
     "vite": "^7.2.4",

--- a/prototyp/src/App.css
+++ b/prototyp/src/App.css
@@ -24,8 +24,16 @@
   z-index: 10;
   display: flex;
   align-items: stretch;
+  justify-content: space-between;
   border-bottom: 0.5px solid var(--border);
   background: var(--bg);
+}
+
+.top-tab-list {
+  position: relative;
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
 }
 
 .tab-item {
@@ -70,6 +78,108 @@
   transition:
     transform 320ms cubic-bezier(0.4, 0, 0.2, 1),
     width 320ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.semantic-context-toggle-wrap {
+  position: relative;
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  border-left: 0.5px solid var(--border);
+  padding: 0 1rem;
+}
+
+.semantic-context-toggle-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+}
+
+.semantic-context-toggle-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 0.625rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: color 180ms ease;
+}
+
+.semantic-context-toggle-label:hover,
+.semantic-context-toggle-input:focus-visible + .semantic-context-toggle-label {
+  color: var(--ink);
+}
+
+.semantic-context-toggle-track {
+  position: relative;
+  width: 2.35rem;
+  height: 1.2rem;
+  border: 0.5px solid var(--border);
+  background: transparent;
+  transition:
+    background 180ms ease,
+    border-color 180ms ease;
+}
+
+.semantic-context-toggle-track::after {
+  position: absolute;
+  top: 0.2rem;
+  left: 0.2rem;
+  width: 0.72rem;
+  height: 0.72rem;
+  background: var(--muted);
+  content: '';
+  transition:
+    background 180ms ease,
+    transform 180ms ease;
+}
+
+.semantic-context-toggle-input:checked + .semantic-context-toggle-label {
+  color: var(--ink);
+}
+
+.semantic-context-toggle-input:checked
+  + .semantic-context-toggle-label
+  .semantic-context-toggle-track {
+  border-color: rgba(240, 45, 0, 0.36);
+  background: rgba(240, 45, 0, 0.06);
+}
+
+.semantic-context-toggle-input:checked
+  + .semantic-context-toggle-label
+  .semantic-context-toggle-track::after {
+  background: var(--red);
+  transform: translateX(1.12rem);
+}
+
+.semantic-context-toggle-tooltip {
+  position: absolute;
+  right: 0.8rem;
+  bottom: -0.55rem;
+  z-index: 30;
+  width: min(20rem, calc(100vw - 2rem));
+  border: 1px solid rgba(240, 45, 0, 0.42);
+  background: var(--bg);
+  color: rgba(17, 24, 39, 0.7);
+  font-size: 0.675rem;
+  line-height: 1.45;
+  opacity: 0;
+  padding: 0.55rem 0.65rem;
+  pointer-events: none;
+  transform: translateY(100%);
+  transition:
+    opacity 160ms ease,
+    transform 160ms ease;
+}
+
+.semantic-context-toggle-wrap:hover .semantic-context-toggle-tooltip,
+.semantic-context-toggle-input:focus-visible
+  ~ .semantic-context-toggle-tooltip {
+  opacity: 1;
+  transform: translateY(calc(100% + 0.2rem));
 }
 
 .app-shell {
@@ -1564,6 +1674,7 @@
 }
 
 .editor-rationale-panel,
+.editor-semantic-context-panel,
 .editor-export-panel {
   padding: 1.2rem;
 }
@@ -1574,6 +1685,16 @@
   flex: 0 0 auto;
   flex-direction: column;
   overflow: visible;
+}
+
+.editor-semantic-context-panel {
+  border-bottom: 0.5px solid var(--border);
+  background: rgba(240, 45, 0, 0.018);
+}
+
+.semantic-context-motion-shell {
+  flex: 0 0 auto;
+  overflow: hidden;
 }
 
 .editor-rationale-tools {
@@ -1627,6 +1748,110 @@
 .editor-sign-group span.selected {
   border-color: var(--ink);
   color: var(--ink);
+}
+
+.semantic-context-field,
+.semantic-context-metaphor span,
+.semantic-context-primary span {
+  display: block;
+  color: var(--muted);
+  font-size: 0.5625rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.semantic-context-head {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.65rem;
+  align-items: center;
+  margin-top: 0.85rem;
+}
+
+.semantic-context-cues {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.semantic-context-cue {
+  display: grid;
+  width: 1.85rem;
+  height: 1.85rem;
+  place-items: center;
+  border: 1px solid rgba(240, 45, 0, 0.42);
+  background: rgba(240, 45, 0, 0.045);
+  color: var(--red);
+  font-size: 0.625rem;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.semantic-context-metaphor {
+  min-width: 0;
+}
+
+.semantic-context-metaphor strong {
+  display: block;
+  margin-top: 0.18rem;
+  font-size: 0.78rem;
+  font-weight: 500;
+  line-height: 1.35;
+}
+
+.semantic-context-primary {
+  margin: 0.85rem 0 0;
+  color: rgba(17, 24, 39, 0.68);
+  font-size: 0.75rem;
+  line-height: 1.55;
+}
+
+.semantic-context-primary span {
+  margin-bottom: 0.3rem;
+}
+
+.semantic-reading-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.75rem;
+}
+
+.semantic-reading-chips span {
+  border: 0.5px solid rgba(17, 24, 39, 0.13);
+  background: rgba(255, 255, 255, 0.32);
+  color: rgba(17, 24, 39, 0.66);
+  font-size: 0.61rem;
+  padding: 0.24rem 0.44rem;
+}
+
+.semantic-boundaries {
+  margin-top: 0.75rem;
+  border: 0.5px solid rgba(240, 45, 0, 0.28);
+  background: rgba(240, 45, 0, 0.035);
+}
+
+.semantic-boundaries summary {
+  cursor: pointer;
+  color: var(--red);
+  font-size: 0.625rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  list-style-position: inside;
+  padding: 0.55rem 0.65rem;
+  text-transform: uppercase;
+}
+
+.semantic-boundaries ul {
+  display: grid;
+  gap: 0.45rem;
+  margin: 0;
+  padding: 0 0.75rem 0.75rem 1.2rem;
+}
+
+.semantic-boundaries li {
+  color: rgba(17, 24, 39, 0.68);
+  font-size: 0.675rem;
+  line-height: 1.45;
 }
 
 .editor-export-panel {
@@ -1800,14 +2025,21 @@
   }
 }
 
-
 @media (max-width: 820px) {
   .top-tabs {
     overflow-x: auto;
   }
 
+  .top-tab-list {
+    flex: 0 0 auto;
+  }
+
   .tab-item {
     white-space: nowrap;
+  }
+
+  .semantic-context-toggle-wrap {
+    min-height: 100%;
   }
 
   .app-shell {
@@ -1947,6 +2179,7 @@
   .editor-selection-panel,
   .editor-preview-panel,
   .editor-rationale-panel,
+  .editor-semantic-context-panel,
   .editor-export-panel {
     padding-right: 1.25rem;
     padding-left: 1.25rem;
@@ -1980,7 +2213,7 @@
   }
 
   .editor-option-summary::after {
-    content: "+";
+    content: '+';
     color: var(--red);
     font-size: 0.875rem;
     font-weight: 400;
@@ -1988,7 +2221,7 @@
   }
 
   .editor-option-group.mobile-open .editor-option-summary::after {
-    content: "-";
+    content: '-';
   }
 
   .editor-option-summary:hover,
@@ -2052,7 +2285,6 @@
   .editor-export-panel {
     min-height: 24rem;
   }
-
 }
 
 @media (max-width: 560px) {
@@ -2109,8 +2341,13 @@
 
   .editor-export-tabs,
   .editor-export-actions,
-  .editor-sign-group {
+  .editor-sign-group,
+  .semantic-context-head {
     flex-wrap: wrap;
+  }
+
+  .semantic-context-head {
+    display: flex;
   }
 
   .editor-export-panel pre {

--- a/prototyp/src/App.tsx
+++ b/prototyp/src/App.tsx
@@ -34,6 +34,7 @@ function App() {
   const [editorSelection, setEditorSelection] = useState<EditorSelection>(
     defaultEditorSelection,
   );
+  const [showSemanticContext, setShowSemanticContext] = useState(false);
   const [transitionDirection, setTransitionDirection] =
     useState<PageTransitionDirection>(0);
 
@@ -88,6 +89,7 @@ function App() {
       <Editor
         onSelectionChange={setEditorSelection}
         selection={editorSelection}
+        showSemanticContext={showSemanticContext}
       />
     );
   }
@@ -101,7 +103,12 @@ function App() {
   }
 
   return (
-    <AppNavigation currentPage={currentPage} onNavigate={navigateToPage}>
+    <AppNavigation
+      currentPage={currentPage}
+      onNavigate={navigateToPage}
+      onSemanticContextToggle={setShowSemanticContext}
+      showSemanticContext={showSemanticContext}
+    >
       <PageTransition direction={transitionDirection} pageKey={currentPage}>
         {pageContent}
       </PageTransition>

--- a/prototyp/src/components/AppNavigation.tsx
+++ b/prototyp/src/components/AppNavigation.tsx
@@ -15,6 +15,8 @@ type NavItem = {
 
 type AppNavigationProps = PageProps & {
   children: ReactNode;
+  onSemanticContextToggle: (isEnabled: boolean) => void;
+  showSemanticContext: boolean;
 };
 
 const navItems: NavItem[] = [
@@ -30,6 +32,8 @@ function AppNavigation({
   children,
   currentPage,
   onNavigate,
+  onSemanticContextToggle,
+  showSemanticContext,
 }: AppNavigationProps) {
   const topRefs = useRef<Partial<Record<PageId, HTMLButtonElement | null>>>({});
   const sideRefs = useRef<Partial<Record<PageId, HTMLButtonElement | null>>>(
@@ -95,9 +99,7 @@ function AppNavigation({
       const step = Math.abs(pageIndex - previousIndex);
       const releaseProgress = Math.min(1, (step + 0.45) / distance);
       const releaseDelay =
-        step === 0
-          ? 70
-          : Math.round(releaseProgress * navigationTransitionMs);
+        step === 0 ? 70 : Math.round(releaseProgress * navigationTransitionMs);
 
       return window.setTimeout(() => {
         setPassingPageIds((activeIds) =>
@@ -114,27 +116,59 @@ function AppNavigation({
   return (
     <div className="app-page">
       <header className="top-tabs" aria-label="Hauptnavigation">
-        {navItems.map((item) => (
-          <MotionActionButton
-            className={currentPage === item.id ? 'tab-item active' : 'tab-item'}
-            key={item.id}
-            onClick={() => onNavigate(item.id)}
-            ref={(node) => {
-              topRefs.current[item.id] = node;
+        <div className="top-tab-list">
+          {navItems.map((item) => (
+            <MotionActionButton
+              className={
+                currentPage === item.id ? 'tab-item active' : 'tab-item'
+              }
+              key={item.id}
+              onClick={() => onNavigate(item.id)}
+              ref={(node) => {
+                topRefs.current[item.id] = node;
+              }}
+              type="button"
+            >
+              {item.label}
+            </MotionActionButton>
+          ))}
+          <span
+            aria-hidden="true"
+            className="top-tab-indicator"
+            style={{
+              transform: `translateX(${topIndicator.left}px)`,
+              width: topIndicator.width,
             }}
-            type="button"
-          >
-            {item.label}
-          </MotionActionButton>
-        ))}
-        <span
-          aria-hidden="true"
-          className="top-tab-indicator"
-          style={{
-            transform: `translateX(${topIndicator.left}px)`,
-            width: topIndicator.width,
-          }}
-        />
+          />
+        </div>
+
+        {currentPage === 'editor' && (
+          <div className="semantic-context-toggle-wrap">
+            <input
+              checked={showSemanticContext}
+              className="semantic-context-toggle-input"
+              id="semantic-context-toggle"
+              onChange={(event) =>
+                onSemanticContextToggle(event.currentTarget.checked)
+              }
+              type="checkbox"
+            />
+            <label
+              className="semantic-context-toggle-label"
+              htmlFor="semantic-context-toggle"
+            >
+              <span>Semantischer Möglichkeitsraum</span>
+              <span
+                aria-hidden="true"
+                className="semantic-context-toggle-track"
+              />
+            </label>
+            <span className="semantic-context-toggle-tooltip" role="tooltip">
+              Zeigt bildhafte Lesart, angrenzende Bedeutungen und Abgrenzungen
+              als konzeptionelle Zusatzebene.
+            </span>
+          </div>
+        )}
       </header>
 
       <div className="app-shell">

--- a/prototyp/src/data/mappings.ts
+++ b/prototyp/src/data/mappings.ts
@@ -5,139 +5,215 @@
  * Dimensionen: feedback, stateChange, direction, hierarchy, attention
  */
 
-import type { MappingDatabase } from "../framework/types";
+import type { MappingDatabase } from '../framework/types';
 
 export const mappings: MappingDatabase = [
-
   // -------------------------------------------------------------------------
   // BUTTON
   // -------------------------------------------------------------------------
 
   {
-    id: "button-feedback-success",
-    component: "button",
-    dimension: "feedback",
-    subcategory: "success",
+    id: 'button-feedback-success',
+    component: 'button',
+    dimension: 'feedback',
+    subcategory: 'success',
     params: {
-      easing: { preset: "easeOut" },
+      easing: { preset: 'easeOut' },
       duration: 250,
       scaleFactor: 0.05, // 1.0 → 1.05 → 1.0
-      scaleMode: "pulse",
+      scaleMode: 'pulse',
       iterations: 1,
     },
     rationale: {
       short:
-        "Die sanfte Ausdehnung und das schnelle Abklingen signalisieren, " +
-        "dass eine Aktion erfolgreich abgeschlossen wurde.",
+        'Die sanfte Ausdehnung und das schnelle Abklingen signalisieren, ' +
+        'dass eine Aktion erfolgreich abgeschlossen wurde.',
       source:
-        "Ikon/Index (Peirce): leichte Expansion ähnelt einer physischen " +
-        "Reaktion auf die erfolgreiche Aktion und verweist damit auf deren Abschluss. " +
-        "Ease-Out: Abklingen als Signal für Abschluss (Zacks & Tversky 2001). " +
-        "Duration 250ms: Standard für primäres Feedback (Head 2016).",
-      references: ["Peirce1931", "ZacksTversky2001", "Head2016"],
-      signType: "icon/index",
+        'Ikon/Index (Peirce): leichte Expansion ähnelt einer physischen ' +
+        'Reaktion auf die erfolgreiche Aktion und verweist damit auf deren Abschluss. ' +
+        'Ease-Out: Abklingen als Signal für Abschluss (Zacks & Tversky 2001). ' +
+        'Duration 250ms: Standard für primäres Feedback (Head 2016).',
+      references: ['Peirce1931', 'ZacksTversky2001', 'Head2016'],
+      signType: 'icon/index',
+      semanticContext: {
+        metaphor: {
+          label: 'Kurzer positiver Impuls als Bestätigung',
+          visualCue: 'pulseSignal',
+        },
+        primaryReading:
+          'Die Aktion wurde erfolgreich abgeschlossen und vom Element bestätigt.',
+        adjacentReadings: [
+          'Aktivierung',
+          'Bestätigung',
+          'kurze Aufmerksamkeitsmarkierung',
+          'haptisches Feedback im übertragenen Sinn',
+        ],
+        boundaries: [
+          'Bleibt Feedback, weil der Pulse unmittelbar nach einer abgeschlossenen Nutzeraktion erscheint.',
+          'Kein Attention-Mapping, weil die Bewegung nicht systeminitiiert Aufmerksamkeit einfordert.',
+        ],
+      },
     },
   },
 
   {
-    id: "button-feedback-error",
-    component: "button",
-    dimension: "feedback",
-    subcategory: "error",
+    id: 'button-feedback-error',
+    component: 'button',
+    dimension: 'feedback',
+    subcategory: 'error',
     params: {
-      easing: { preset: "sharp" },
+      easing: { preset: 'sharp' },
       duration: 350,
-      direction: "x",
+      direction: 'x',
       translatePx: 8,
       iterations: 1,
       keyframes: {
         values: [0, -8, 8, -8, 8, -4, 0],
-        times:  [0, 0.15, 0.30, 0.45, 0.60, 0.80, 1.0],
+        times: [0, 0.15, 0.3, 0.45, 0.6, 0.8, 1.0],
       },
     },
     accessibility: {
-      reducedMotion: "replace",
+      reducedMotion: 'replace',
     },
     rationale: {
       short:
-        "Die horizontale Schüttelbewegung greift auf die vertraute " +
-        "Ablehnungsgeste des Kopfschüttelns zurück und kommuniziert, " +
-        "dass eine Eingabe nicht akzeptiert wurde.",
+        'Die horizontale Schüttelbewegung greift auf die vertraute ' +
+        'Ablehnungsgeste des Kopfschüttelns zurück und kommuniziert, ' +
+        'dass eine Eingabe nicht akzeptiert wurde.',
       source:
-        "Index (Peirce): assoziative Verbindung zu Kopfschütteln als " +
-        "Ablehnungsgeste. Direction Bias (Ware 2012): horizontale Bewegung " +
-        "kodiert Ablehnung. Sharp easing: Abruptheit verstärkt Fehlercharakter " +
-        "(Chang & Ungar 1993). translatePx ±8px: mittelgroß, klar wahrnehmbar " +
-        "ohne visuell aggressiv zu wirken (Bartram et al. 2003).",
-      references: ["Peirce1931", "Ware2012", "ChangUngar1993", "BartramWareCalvert2003"],
-      signType: "index",
+        'Index (Peirce): assoziative Verbindung zu Kopfschütteln als ' +
+        'Ablehnungsgeste. Direction Bias (Ware 2012): horizontale Bewegung ' +
+        'kodiert Ablehnung. Sharp easing: Abruptheit verstärkt Fehlercharakter ' +
+        '(Chang & Ungar 1993). translatePx ±8px: mittelgroß, klar wahrnehmbar ' +
+        'ohne visuell aggressiv zu wirken (Bartram et al. 2003).',
+      references: [
+        'Peirce1931',
+        'Ware2012',
+        'ChangUngar1993',
+        'BartramWareCalvert2003',
+      ],
+      signType: 'index',
+      semanticContext: {
+        metaphor: {
+          label: 'Kopfschütteln oder Abwinken als Ablehnung',
+          visualCue: 'refusalGesture',
+        },
+        primaryReading:
+          'Die Nutzeraktion wurde nicht akzeptiert oder ist fehlgeschlagen.',
+        adjacentReadings: [
+          'Verneinung',
+          'Zurückweisung',
+          'ungültige Aktion',
+          'kurzfristige Aufmerksamkeitslenkung',
+        ],
+        boundaries: [
+          'Bleibt Feedback, weil die Bewegung auf eine konkrete Nutzeraktion reagiert.',
+          'In einem systeminitiierten Kontext ohne direkten Handlungsauslöser wäre derselbe Shake eher Attention.',
+        ],
+      },
     },
   },
 
   {
-    id: "button-attention-warning",
-    component: "button",
-    dimension: "attention",
-    subcategory: "warning",
+    id: 'button-attention-warning',
+    component: 'button',
+    dimension: 'attention',
+    subcategory: 'warning',
     params: {
-      easing: { preset: "easeInOut" },
+      easing: { preset: 'easeInOut' },
       duration: 600,
       scaleFactor: 0.03, // 1.0 → 1.03 → 1.0
-      scaleMode: "pulse",
+      scaleMode: 'pulse',
       iterations: 3,
       // Bewusst Attention statt Feedback: Die Animation wird systeminitiiert
       // ausgelöst und ist keine unmittelbare Reaktion auf einen Button-Klick.
     },
     accessibility: {
-      reducedMotion: "shorten",
+      reducedMotion: 'shorten',
     },
     rationale: {
       short:
-        "Das wiederholte, gleichmäßige Pulsieren fordert Aufmerksamkeit ein, " +
-        "ohne Dringlichkeit zu signalisieren. Es endet nach drei Zyklen " +
-        "und unterscheidet sich damit von persistenten Aufmerksamkeitssignalen.",
+        'Das wiederholte, gleichmäßige Pulsieren fordert Aufmerksamkeit ein, ' +
+        'ohne Dringlichkeit zu signalisieren. Es endet nach drei Zyklen ' +
+        'und unterscheidet sich damit von persistenten Aufmerksamkeitssignalen.',
       source:
-        "Attention-Dimension (nicht Feedback): Das Signal ist systeminitiiert, " +
-        "nicht Reaktion auf eine abgeschlossene Nutzeraktion. " +
-        "Index (Peirce): wiederholte Bewegung als kultureller Index für " +
-        "Persistenz (Bartram et al. 2003). Ease-In-Out: symmetrische Kurve, " +
-        "keine Abruptheit. Iterations 3: endet von selbst, abgegrenzt von " +
-        "button-attention-persistent (Infinity).",
-      references: ["Peirce1931", "BartramWareCalvert2003"],
-      signType: "index",
+        'Attention-Dimension (nicht Feedback): Das Signal ist systeminitiiert, ' +
+        'nicht Reaktion auf eine abgeschlossene Nutzeraktion. ' +
+        'Index (Peirce): wiederholte Bewegung als kultureller Index für ' +
+        'Persistenz (Bartram et al. 2003). Ease-In-Out: symmetrische Kurve, ' +
+        'keine Abruptheit. Iterations 3: endet von selbst, abgegrenzt von ' +
+        'button-attention-persistent (Infinity).',
+      references: ['Peirce1931', 'BartramWareCalvert2003'],
+      signType: 'index',
+      semanticContext: {
+        metaphor: {
+          label: 'Begrenztes Pulsieren als Warnhinweis',
+          visualCue: 'pulseSignal',
+        },
+        primaryReading:
+          'Das System fordert Aufmerksamkeit für einen begrenzten Warnzustand ein.',
+        adjacentReadings: [
+          'Hinweis',
+          'milde Dringlichkeit',
+          'Erinnerung',
+          'vorbereitendes Feedback',
+        ],
+        boundaries: [
+          'Bleibt Attention, weil das Signal systeminitiiert ist und keine abgeschlossene Nutzeraktion bewertet.',
+          'Nicht persistent, weil die Wiederholung nach drei Zyklen endet.',
+        ],
+      },
     },
   },
 
   {
-    id: "button-attention-persistent",
-    component: "button",
-    dimension: "attention",
-    subcategory: "persistent",
+    id: 'button-attention-persistent',
+    component: 'button',
+    dimension: 'attention',
+    subcategory: 'persistent',
     params: {
-      easing: { preset: "easeInOut" },
+      easing: { preset: 'easeInOut' },
       duration: 1000,
       scaleFactor: 0.04, // 1.0 → 1.04 → 1.0
-      scaleMode: "pulse",
+      scaleMode: 'pulse',
       iterations: Infinity,
     },
     accessibility: {
-      reducedMotion: "static",
+      reducedMotion: 'static',
     },
     rationale: {
       short:
-        "Das langsame, gleichmäßige Pulsieren signalisiert, dass eine Aktion " +
-        "aussteht, ohne aggressiv zu wirken. Die endlose Wiederholung endet, " +
-        "sobald der Nutzer reagiert.",
+        'Das langsame, gleichmäßige Pulsieren signalisiert, dass eine Aktion ' +
+        'aussteht, ohne aggressiv zu wirken. Die endlose Wiederholung endet, ' +
+        'sobald der Nutzer reagiert.',
       source:
-        "Index (Peirce): wiederholte Bewegung als Verweis auf ausstehende " +
-        "Aktion. Ease-In-Out: gleichmäßig, nicht dringend. Duration 1000ms: " +
-        "langsam genug, um periphere Wahrnehmung zu aktivieren ohne " +
-        "Hauptaufgabe zu stören (Bartram et al. 2003). Iterations Infinity: " +
-        "Persistenz als semantisches Ziel. Accessibility: endlose Bewegung " +
-        "muss im Editor über prefers-reduced-motion reduziert oder ersetzt " +
-        "werden können (WCAG 2.1 SC 2.3.3).",
-      references: ["Peirce1931", "BartramWareCalvert2003", "WCAG21"],
-      signType: "index",
+        'Index (Peirce): wiederholte Bewegung als Verweis auf ausstehende ' +
+        'Aktion. Ease-In-Out: gleichmäßig, nicht dringend. Duration 1000ms: ' +
+        'langsam genug, um periphere Wahrnehmung zu aktivieren ohne ' +
+        'Hauptaufgabe zu stören (Bartram et al. 2003). Iterations Infinity: ' +
+        'Persistenz als semantisches Ziel. Accessibility: endlose Bewegung ' +
+        'muss im Editor über prefers-reduced-motion reduziert oder ersetzt ' +
+        'werden können (WCAG 2.1 SC 2.3.3).',
+      references: ['Peirce1931', 'BartramWareCalvert2003', 'WCAG21'],
+      signType: 'index',
+      semanticContext: {
+        metaphor: {
+          label: 'Anhaltendes Pulsieren als ausstehende Handlung',
+          visualCue: 'pulseSignal',
+        },
+        primaryReading:
+          'Eine ausstehende Aktion bleibt sichtbar, bis der Nutzer reagiert.',
+        adjacentReadings: [
+          'Erinnerung',
+          'Handlungsaufforderung',
+          'anhaltender Hinweis',
+          'nicht abgeschlossener Zustand',
+        ],
+        boundaries: [
+          'Bleibt Attention, weil die Bewegung keinen Erfolg oder Fehler bewertet.',
+          'Unterscheidet sich von Warning durch die unbegrenzte Wiederholung bis zur Nutzerreaktion.',
+        ],
+      },
     },
   },
 
@@ -146,55 +222,94 @@ export const mappings: MappingDatabase = [
   // -------------------------------------------------------------------------
 
   {
-    id: "toggle-stateChange-toggleOn",
-    component: "toggle",
-    dimension: "stateChange",
-    subcategory: "toggleOn",
+    id: 'toggle-stateChange-toggleOn',
+    component: 'toggle',
+    dimension: 'stateChange',
+    subcategory: 'toggleOn',
     params: {
-      easing: { preset: "easeInOut" },
+      easing: { preset: 'easeInOut' },
       duration: 220,
-      direction: "x",
+      direction: 'x',
       trackFactor: 1.0, // volle komponenteneigene Track-Breite vorwärts
       iterations: 1,
     },
     rationale: {
       short:
-        "Die horizontale Bewegung des Thumb-Elements ähnelt dem physischen " +
-        "Umlegen eines Schalters und kommuniziert, dass das Element aktiviert wurde.",
+        'Die horizontale Bewegung des Thumb-Elements ähnelt dem physischen ' +
+        'Umlegen eines Schalters und kommuniziert, dass das Element aktiviert wurde.',
       source:
-        "Ikon (Peirce): ähnelt dem physischen Umlegen eines Schalters " +
-        "(Thomas & Johnston 1981, physical analogy). Ease-In-Out: symmetrische " +
-        "Kurve für symmetrischen Zustandswechsel (Zacks & Tversky 2001). " +
-        "Duration 220ms: schnell genug für direkte Reaktion (Head 2016).",
-      references: ["Peirce1931", "ThomasJohnston1981", "ZacksTversky2001", "Head2016"],
-      signType: "icon",
+        'Ikon (Peirce): ähnelt dem physischen Umlegen eines Schalters ' +
+        '(Thomas & Johnston 1981, physical analogy). Ease-In-Out: symmetrische ' +
+        'Kurve für symmetrischen Zustandswechsel (Zacks & Tversky 2001). ' +
+        'Duration 220ms: schnell genug für direkte Reaktion (Head 2016).',
+      references: [
+        'Peirce1931',
+        'ThomasJohnston1981',
+        'ZacksTversky2001',
+        'Head2016',
+      ],
+      signType: 'icon',
+      semanticContext: {
+        metaphor: {
+          label: 'Schalterbewegung in den aktiven Zustand',
+          visualCue: 'toggleTravel',
+        },
+        primaryReading: 'Das Element wechselt von inaktiv zu aktiv.',
+        adjacentReadings: [
+          'Aktivierung',
+          'Richtungsbewegung',
+          'Auswahl',
+          'physischer Schalter',
+        ],
+        boundaries: [
+          'Bleibt State Change, weil die Bewegung zwischen zwei Zuständen derselben Komponente stattfindet.',
+          'Keine Direction-Dimension, weil die x-Bewegung keine Navigation durch Inhalte beschreibt.',
+        ],
+      },
     },
   },
 
   {
-    id: "toggle-stateChange-toggleOff",
-    component: "toggle",
-    dimension: "stateChange",
-    subcategory: "toggleOff",
+    id: 'toggle-stateChange-toggleOff',
+    component: 'toggle',
+    dimension: 'stateChange',
+    subcategory: 'toggleOff',
     params: {
-      easing: { preset: "easeInOut" },
+      easing: { preset: 'easeInOut' },
       duration: 220,
-      direction: "x",
+      direction: 'x',
       trackFactor: -1.0, // volle komponenteneigene Track-Breite rückwärts
       iterations: 1,
     },
     rationale: {
       short:
-        "Die umgekehrte Bewegung des Thumb-Elements kommuniziert, dass das " +
-        "Element deaktiviert wurde. Identische Duration und Easing wie Toggle On " +
-        "verhindern eine irreführende Hierarchie zwischen den Zuständen.",
+        'Die umgekehrte Bewegung des Thumb-Elements kommuniziert, dass das ' +
+        'Element deaktiviert wurde. Identische Duration und Easing wie Toggle On ' +
+        'verhindern eine irreführende Hierarchie zwischen den Zuständen.',
       source:
-        "Ikon (Peirce): Umkehrung der Toggle-On-Bewegung. Ease-In-Out und " +
-        "Duration identisch zu toggleOn: Konsistenzprinzip, asymmetrische " +
-        "Parameter würden eine semantisch falsche Gewichtung der Zustände " +
-        "erzeugen (Norman 2013, signifier consistency).",
-      references: ["Peirce1931", "Norman2013"],
-      signType: "icon",
+        'Ikon (Peirce): Umkehrung der Toggle-On-Bewegung. Ease-In-Out und ' +
+        'Duration identisch zu toggleOn: Konsistenzprinzip, asymmetrische ' +
+        'Parameter würden eine semantisch falsche Gewichtung der Zustände ' +
+        'erzeugen (Norman 2013, signifier consistency).',
+      references: ['Peirce1931', 'Norman2013'],
+      signType: 'icon',
+      semanticContext: {
+        metaphor: {
+          label: 'Schalterbewegung zurück in den inaktiven Zustand',
+          visualCue: 'toggleTravel',
+        },
+        primaryReading: 'Das Element wechselt von aktiv zu inaktiv.',
+        adjacentReadings: [
+          'Deaktivierung',
+          'Rücknahme',
+          'Zustandswechsel',
+          'physischer Schalter',
+        ],
+        boundaries: [
+          'Bleibt State Change, weil die Bewegung die Umkehrung desselben Komponenten-Zustands ist.',
+          'Kein Error- oder Hierarchy-Signal, weil die Deaktivierung nicht als Abwertung oder Fehler markiert wird.',
+        ],
+      },
     },
   },
 
@@ -203,16 +318,16 @@ export const mappings: MappingDatabase = [
   // -------------------------------------------------------------------------
 
   {
-    id: "toast-feedback-success",
-    component: "toast",
-    dimension: "feedback",
-    subcategory: "success",
+    id: 'toast-feedback-success',
+    component: 'toast',
+    dimension: 'feedback',
+    subcategory: 'success',
     params: {
-      easing: { preset: "spring" },
+      easing: { preset: 'spring' },
       duration: 300,
-      direction: "y",
-      translateDistance: "self",
-      translateFrom: "bottom",
+      direction: 'y',
+      translateDistance: 'self',
+      translateFrom: 'bottom',
       iterations: 1,
       opacity: [0, 1],
       springConfig: {
@@ -222,95 +337,131 @@ export const mappings: MappingDatabase = [
       },
     },
     accessibility: {
-      reducedMotion: "replace",
+      reducedMotion: 'replace',
     },
     rationale: {
       short:
-        "Der Toast fährt von unten ein und federt leicht nach. Der " +
-        "Überschwinger signalisiert, dass eine Aktion erfolgreich abgeschlossen wurde.",
+        'Der Toast fährt von unten ein und federt leicht nach. Der ' +
+        'Überschwinger signalisiert, dass eine Aktion erfolgreich abgeschlossen wurde.',
       source:
-        "Index (Peirce): Erscheinen aus dem Bildschirmrand als kausaler " +
-        "Verweis auf Aktionsergebnis. Spring-Easing: Follow-Through-Prinzip " +
-        "(Thomas & Johnston 1981) kommuniziert physikalische Substanz und " +
-        "positive Energie. Duration 300ms, stiffness 360 und damping 20: schnelle, " +
-        "klar wahrnehmbare, aber kontrollierte federnde " +
-        "Einfahrt als Positivsignal (Head 2016).",
-      references: ["Peirce1931", "ThomasJohnston1981", "Head2016"],
-      signType: "index",
+        'Index (Peirce): Erscheinen aus dem Bildschirmrand als kausaler ' +
+        'Verweis auf Aktionsergebnis. Spring-Easing: Follow-Through-Prinzip ' +
+        '(Thomas & Johnston 1981) kommuniziert physikalische Substanz und ' +
+        'positive Energie. Duration 300ms, stiffness 360 und damping 20: schnelle, ' +
+        'klar wahrnehmbare, aber kontrollierte federnde ' +
+        'Einfahrt als Positivsignal (Head 2016).',
+      references: ['Peirce1931', 'ThomasJohnston1981', 'Head2016'],
+      signType: 'index',
+      semanticContext: {
+        metaphor: {
+          label: 'Eintreffende Bestätigung mit positivem Nachfedern',
+          visualCue: ['arrival', 'pulseSignal'],
+        },
+        primaryReading:
+          'Ein positives Aktionsergebnis erscheint als sichtbare Rückmeldung.',
+        adjacentReadings: [
+          'Benachrichtigung',
+          'neue Information',
+          'Bestätigung',
+          'kurze Aufmerksamkeit',
+        ],
+        boundaries: [
+          'Bleibt Feedback, weil der Toast ein Aktionsergebnis kommuniziert.',
+          'Nicht nur Attention, weil das Nachfedern positiv auf den Abschluss verweist.',
+        ],
+      },
     },
   },
 
   {
-    id: "toast-feedback-error",
-    component: "toast",
-    dimension: "feedback",
-    subcategory: "error",
+    id: 'toast-feedback-error',
+    component: 'toast',
+    dimension: 'feedback',
+    subcategory: 'error',
     params: {
-      easing: { preset: "sharp" },
+      easing: { preset: 'sharp' },
       duration: 320,
       iterations: 1,
       motionPhases: [
         {
-          id: "enter",
+          id: 'enter',
           duration: 160,
-          direction: "y",
-          translateDistance: "self",
-          translateFrom: "bottom",
+          direction: 'y',
+          translateDistance: 'self',
+          translateFrom: 'bottom',
           opacity: [0, 1],
         },
         {
-          id: "shake",
+          id: 'shake',
           duration: 160,
-          direction: "x",
+          direction: 'x',
           keyframes: {
             values: [0, -6, 6, -6, 6, 0],
-            times:  [0, 0.2, 0.4, 0.6, 0.8, 1.0],
+            times: [0, 0.2, 0.4, 0.6, 0.8, 1.0],
           },
         },
       ],
     },
     accessibility: {
-      reducedMotion: "replace",
+      reducedMotion: 'replace',
     },
     rationale: {
       short:
-        "Der Toast erscheint abrupt und schüttelt sich kurz horizontal. " +
-        "Die Kombination aus scharfer Einfahrt und Shake macht den " +
-        "Fehlercharakter unmittelbar erkennbar.",
+        'Der Toast erscheint abrupt und schüttelt sich kurz horizontal. ' +
+        'Die Kombination aus scharfer Einfahrt und Shake macht den ' +
+        'Fehlercharakter unmittelbar erkennbar.',
       source:
-        "Index (Peirce): horizontaler Shake als Ablehnungsindex " +
-        "(Ware 2012, Direction Bias). Sharp easing: Abruptheit verstärkt " +
-        "Fehlercharakter, kein Follow-Through, keine Freudigkeit. " +
-        "Zweiphasige Animation: Staging-Prinzip (Heer & Robertson 2007). " +
-        "Duration 320ms: kürzer als warning, betont Unmittelbarkeit.",
-      references: ["Peirce1931", "Ware2012", "HeerRobertson2007"],
-      signType: "index",
+        'Index (Peirce): horizontaler Shake als Ablehnungsindex ' +
+        '(Ware 2012, Direction Bias). Sharp easing: Abruptheit verstärkt ' +
+        'Fehlercharakter, kein Follow-Through, keine Freudigkeit. ' +
+        'Zweiphasige Animation: Staging-Prinzip (Heer & Robertson 2007). ' +
+        'Duration 320ms: kürzer als warning, betont Unmittelbarkeit.',
+      references: ['Peirce1931', 'Ware2012', 'HeerRobertson2007'],
+      signType: 'index',
+      semanticContext: {
+        metaphor: {
+          label: 'Eintretende Meldung mit Ablehnungsakzent',
+          visualCue: ['arrival', 'refusalGesture'],
+        },
+        primaryReading:
+          'Eine Fehlermeldung erscheint und markiert das Ergebnis einer fehlgeschlagenen Aktion.',
+        adjacentReadings: [
+          'dringliche Information',
+          'Aufmerksamkeitssignal',
+          'Ablehnung',
+          'Unterbrechung',
+        ],
+        boundaries: [
+          'Bleibt Feedback, weil der Toast ein Ergebnis kommuniziert.',
+          'Die Aufmerksamkeit entsteht sekundär durch Sichtbarkeit und Shake, ist aber nicht der primäre Zweck.',
+        ],
+      },
     },
   },
 
   {
-    id: "toast-feedback-warning",
-    component: "toast",
-    dimension: "feedback",
-    subcategory: "warning",
+    id: 'toast-feedback-warning',
+    component: 'toast',
+    dimension: 'feedback',
+    subcategory: 'warning',
     params: {
-      easing: { preset: "easeInOut" },
+      easing: { preset: 'easeInOut' },
       duration: 420,
       iterations: 1,
       motionPhases: [
         {
-          id: "enter",
+          id: 'enter',
           delay: 80,
           duration: 260,
-          direction: "y",
-          translateDistance: "self",
-          translateFrom: "bottom",
+          direction: 'y',
+          translateDistance: 'self',
+          translateFrom: 'bottom',
           opacity: [0, 1],
         },
         {
-          id: "nudge",
+          id: 'nudge',
           duration: 160,
-          direction: "y",
+          direction: 'y',
           keyframes: {
             values: [0, -5, 0],
             times: [0, 0.5, 1],
@@ -319,46 +470,64 @@ export const mappings: MappingDatabase = [
       ],
     },
     accessibility: {
-      reducedMotion: "replace",
+      reducedMotion: 'replace',
     },
     rationale: {
       short:
-        "Der Toast erscheint kontrolliert von unten und setzt nach der Ankunft " +
-        "einen moderaten vertikalen Nudge. Die Bewegung signalisiert, dass " +
-        "Aufmerksamkeit erwünscht ist, aber keine sofortige Aktion erforderlich.",
+        'Der Toast erscheint kontrolliert von unten und setzt nach der Ankunft ' +
+        'einen moderaten vertikalen Nudge. Die Bewegung signalisiert, dass ' +
+        'Aufmerksamkeit erwünscht ist, aber keine sofortige Aktion erforderlich.',
       source:
-        "Index (Peirce): Erscheinen aus dem Bildschirmrand. Ease-In-Out: " +
-        "keine Abruptheit, kein Follow-Through, ruhige Mitteilung ohne " +
-        "emotionale Valenz. Duration 420ms + delay 80ms: zeitlich " +
-        "zurückgenommener als success (300ms) und error (320ms), ohne " +
-        "als dringlicher Fehler zu wirken. Der anschließende y-Nudge " +
-        "setzt ein moderates Warnsignal ohne Fehler-Shake oder positiven Spring " +
-        "(Head 2016; Bartram et al. 2003).",
-      references: ["Peirce1931", "Head2016", "BartramWareCalvert2003"],
-      signType: "index",
+        'Index (Peirce): Erscheinen aus dem Bildschirmrand. Ease-In-Out: ' +
+        'keine Abruptheit, kein Follow-Through, ruhige Mitteilung ohne ' +
+        'emotionale Valenz. Duration 420ms + delay 80ms: zeitlich ' +
+        'zurückgenommener als success (300ms) und error (320ms), ohne ' +
+        'als dringlicher Fehler zu wirken. Der anschließende y-Nudge ' +
+        'setzt ein moderates Warnsignal ohne Fehler-Shake oder positiven Spring ' +
+        '(Head 2016; Bartram et al. 2003).',
+      references: ['Peirce1931', 'Head2016', 'BartramWareCalvert2003'],
+      signType: 'index',
+      semanticContext: {
+        metaphor: {
+          label: 'Eintreffende Warnung mit moderatem Hinweisstoß',
+          visualCue: ['arrival', 'nudgeSignal'],
+        },
+        primaryReading:
+          'Eine Warnmeldung erscheint und signalisiert Aufmerksamkeit ohne akute Fehlerdringlichkeit.',
+        adjacentReadings: [
+          'Hinweis',
+          'Information',
+          'milde Dringlichkeit',
+          'Aufmerksamkeitssignal',
+        ],
+        boundaries: [
+          'Bleibt Feedback, weil die Meldung eine bewertete Situation kommuniziert.',
+          'Nicht Error, weil der Nudge moderat bleibt und keinen Ablehnungs-Shake nutzt.',
+        ],
+      },
     },
   },
 
   {
-    id: "toast-attention-oneShot",
-    component: "toast",
-    dimension: "attention",
-    subcategory: "oneShot",
+    id: 'toast-attention-oneShot',
+    component: 'toast',
+    dimension: 'attention',
+    subcategory: 'oneShot',
     params: {
-      easing: { preset: "easeOut" },
+      easing: { preset: 'easeOut' },
       duration: 760,
       iterations: 1,
       motionPhases: [
         {
-          id: "enter",
+          id: 'enter',
           duration: 320,
-          direction: "y",
-          translateDistance: "self",
-          translateFrom: "bottom",
+          direction: 'y',
+          translateDistance: 'self',
+          translateFrom: 'bottom',
           opacity: [0, 1],
         },
         {
-          id: "pulse",
+          id: 'pulse',
           duration: 440,
           scaleKeyframes: {
             values: [1, 1.025, 1, 1.025, 1],
@@ -368,25 +537,43 @@ export const mappings: MappingDatabase = [
       ],
     },
     accessibility: {
-      reducedMotion: "replace",
+      reducedMotion: 'replace',
     },
     rationale: {
       short:
-        "Der Toast fährt ruhig von unten ein und gibt zwei subtile Scale-Impulse. " +
-        "Das Signal zeigt, dass neue Information angekommen ist, ohne " +
-        "das Ergebnis einer Nutzeraktion zu kommunizieren.",
+        'Der Toast fährt ruhig von unten ein und gibt zwei subtile Scale-Impulse. ' +
+        'Das Signal zeigt, dass neue Information angekommen ist, ohne ' +
+        'das Ergebnis einer Nutzeraktion zu kommunizieren.',
       source:
-        "Attention-Dimension: systeminitiiertes Signal ohne vorherige " +
-        "Nutzeraktion, strukturell verschieden von toast-feedback-success. " +
-        "Ease-Out statt Spring: kein Follow-Through, ruhigere Ankunft " +
-        "ohne positive Energie. Duration 760ms: genug Zeit für Einfahrt und " +
-        "zwei subtile Scale-Impulse, ohne Dringlichkeit zu erzeugen. " +
-        "Der Scale-Pulse wirkt als Aufmerksamkeitssignal, ohne den warnenden " +
-        "y-Nudge oder den positiven Spring der Feedback-Mappings zu übernehmen. " +
-        "Bartram et al. (2003) stützen die Annahme, dass einfache " +
-        "Bewegungsattribute periphere Aufmerksamkeit lenken können.",
-      references: ["Peirce1931", "BartramWareCalvert2003"],
-      signType: "index",
+        'Attention-Dimension: systeminitiiertes Signal ohne vorherige ' +
+        'Nutzeraktion, strukturell verschieden von toast-feedback-success. ' +
+        'Ease-Out statt Spring: kein Follow-Through, ruhigere Ankunft ' +
+        'ohne positive Energie. Duration 760ms: genug Zeit für Einfahrt und ' +
+        'zwei subtile Scale-Impulse, ohne Dringlichkeit zu erzeugen. ' +
+        'Der Scale-Pulse wirkt als Aufmerksamkeitssignal, ohne den warnenden ' +
+        'y-Nudge oder den positiven Spring der Feedback-Mappings zu übernehmen. ' +
+        'Bartram et al. (2003) stützen die Annahme, dass einfache ' +
+        'Bewegungsattribute periphere Aufmerksamkeit lenken können.',
+      references: ['Peirce1931', 'BartramWareCalvert2003'],
+      signType: 'index',
+      semanticContext: {
+        metaphor: {
+          label: 'Neue Information macht sich kurz bemerkbar',
+          visualCue: ['arrival', 'pulseSignal'],
+        },
+        primaryReading:
+          'Eine systeminitiierte Information fordert einmalig Aufmerksamkeit ein.',
+        adjacentReadings: [
+          'Benachrichtigung',
+          'neue Information',
+          'milde Hervorhebung',
+          'kurzer Hinweis',
+        ],
+        boundaries: [
+          'Bleibt Attention, weil kein Ergebnis einer Nutzeraktion kommuniziert wird.',
+          'Nicht Success, weil die Ankunft bewusst ohne positiven Spring und ohne Ergebnisbezug gestaltet ist.',
+        ],
+      },
     },
   },
 
@@ -395,47 +582,65 @@ export const mappings: MappingDatabase = [
   // -------------------------------------------------------------------------
 
   {
-    id: "modal-hierarchy-toForeground",
-    component: "modal",
-    dimension: "hierarchy",
-    subcategory: "toForeground",
+    id: 'modal-hierarchy-toForeground',
+    component: 'modal',
+    dimension: 'hierarchy',
+    subcategory: 'toForeground',
     params: {
-      easing: { preset: "easeOut" },
+      easing: { preset: 'easeOut' },
       duration: 300,
       scaleFactor: 0.05, // 0.95 → 1.0
-      scaleMode: "scaleIn",
+      scaleMode: 'scaleIn',
       iterations: 1,
       opacity: [0, 1],
     },
     accessibility: {
-      reducedMotion: "replace",
+      reducedMotion: 'replace',
     },
     rationale: {
       short:
-        "Das Modal wächst leicht auf seine finale Größe und wird dabei " +
-        "eingeblendet. Die Skalierung ähnelt dem physikalischen Herantreten " +
-        "eines Objekts und kommuniziert, dass dieses Element nun primäre " +
-        "Aufmerksamkeit beansprucht.",
+        'Das Modal wächst leicht auf seine finale Größe und wird dabei ' +
+        'eingeblendet. Die Skalierung ähnelt dem physikalischen Herantreten ' +
+        'eines Objekts und kommuniziert, dass dieses Element nun primäre ' +
+        'Aufmerksamkeit beansprucht.',
       source:
-        "Ikon (Peirce): Skalierung ähnelt physikalischer Annäherung. " +
-        "Ease-Out: Ankommen als Abklingsignal (Zacks & Tversky 2001). " +
-        "scaleFactor 0.05 + Opacity 0→1: kombinierter Übergang für " +
-        "wahrgenommene Tiefe (Material Design 3).",
-      references: ["Peirce1931", "ZacksTversky2001", "MaterialDesign3"],
-      signType: "icon",
+        'Ikon (Peirce): Skalierung ähnelt physikalischer Annäherung. ' +
+        'Ease-Out: Ankommen als Abklingsignal (Zacks & Tversky 2001). ' +
+        'scaleFactor 0.05 + Opacity 0→1: kombinierter Übergang für ' +
+        'wahrgenommene Tiefe (Material Design 3).',
+      references: ['Peirce1931', 'ZacksTversky2001', 'MaterialDesign3'],
+      signType: 'icon',
+      semanticContext: {
+        metaphor: {
+          label: 'Das Modal tritt in den Vordergrund',
+          visualCue: 'foreground',
+        },
+        primaryReading:
+          'Ein Element tritt in den Vordergrund und beansprucht primäre Aufmerksamkeit.',
+        adjacentReadings: [
+          'Erscheinen',
+          'Fokuswechsel',
+          'räumliche Annäherung',
+          'neue Aufgabe',
+        ],
+        boundaries: [
+          'Bleibt Hierarchy, weil die Bewegung keine Navigationsrichtung beschreibt.',
+          'Entscheidend ist die Veränderung der visuellen Priorität, nicht ein Weg durch den Navigationsverlauf.',
+        ],
+      },
     },
   },
 
   {
-    id: "modal-hierarchy-toBackground",
-    component: "modal",
-    dimension: "hierarchy",
-    subcategory: "toBackground",
+    id: 'modal-hierarchy-toBackground',
+    component: 'modal',
+    dimension: 'hierarchy',
+    subcategory: 'toBackground',
     params: {
-      easing: { preset: "easeIn" },
+      easing: { preset: 'easeIn' },
       duration: 250,
       scaleFactor: 0.04, // 1.0 → 0.96
-      scaleMode: "scaleOut",
+      scaleMode: 'scaleOut',
       iterations: 1,
       // Für Modal bedeutet "toBackground" hier: verliert Vordergrundpriorität
       // und wird aus dem aktiven Fokus entfernt. Ein halbtransparent sichtbares
@@ -444,160 +649,262 @@ export const mappings: MappingDatabase = [
       opacity: [1, 0],
     },
     accessibility: {
-      reducedMotion: "replace",
+      reducedMotion: 'replace',
     },
     rationale: {
       short:
-        "Das Modal schrumpft leicht und wird ausgeblendet. Die Verkleinerung " +
-        "kommuniziert, dass die Ebene ihre Vordergrundpriorität verliert " +
-        "und aus dem aktiven Fokus zurücktritt.",
+        'Das Modal schrumpft leicht und wird ausgeblendet. Die Verkleinerung ' +
+        'kommuniziert, dass die Ebene ihre Vordergrundpriorität verliert ' +
+        'und aus dem aktiven Fokus zurücktritt.',
       source:
-        "Ikon (Peirce): Verkleinerung ähnelt physikalischem Entfernen. " +
-        "Ease-In: Zurücktreten als Aufbaukurve (Zacks & Tversky 2001). " +
-        "Beim Modal wird der Hierarchieverlust als Entfernen aus dem aktiven " +
-        "Fokus operationalisiert, nicht als dauerhaft sichtbare Halbtransparenz. " +
-        "Duration 250ms: kürzer als toForeground, Hintergrundprozess " +
-        "ist weniger bedeutsam.",
-      references: ["Peirce1931", "ZacksTversky2001", "Head2016"],
-      signType: "icon",
+        'Ikon (Peirce): Verkleinerung ähnelt physikalischem Entfernen. ' +
+        'Ease-In: Zurücktreten als Aufbaukurve (Zacks & Tversky 2001). ' +
+        'Beim Modal wird der Hierarchieverlust als Entfernen aus dem aktiven ' +
+        'Fokus operationalisiert, nicht als dauerhaft sichtbare Halbtransparenz. ' +
+        'Duration 250ms: kürzer als toForeground, Hintergrundprozess ' +
+        'ist weniger bedeutsam.',
+      references: ['Peirce1931', 'ZacksTversky2001', 'Head2016'],
+      signType: 'icon',
+      semanticContext: {
+        metaphor: {
+          label: 'Das Modal tritt aus dem aktiven Fokus zurück',
+          visualCue: 'backgroundRecede',
+        },
+        primaryReading:
+          'Ein Element verliert seine Vordergrundpriorität und wird aus dem aktiven Fokus entfernt.',
+        adjacentReadings: [
+          'Schließen',
+          'Fokusverlust',
+          'Rücktritt',
+          'Entfernung aus dem Vordergrund',
+        ],
+        boundaries: [
+          'Bleibt Hierarchy, weil der Bedeutungswechsel über visuelle Priorität und Fokus entsteht.',
+          'Nicht Direction, weil keine Navigationsrichtung oder neue Ebene kommuniziert wird.',
+        ],
+      },
     },
   },
 
   {
-    id: "modal-direction-enter",
-    component: "modal",
-    dimension: "direction",
-    subcategory: "enter",
+    id: 'modal-direction-enter',
+    component: 'modal',
+    dimension: 'direction',
+    subcategory: 'enter',
     params: {
-      easing: { preset: "easeOut" },
+      easing: { preset: 'easeOut' },
       duration: 350,
-      direction: "y",
-      translateDistance: "self",
-      translateFrom: "bottom",
+      direction: 'y',
+      translateDistance: 'self',
+      translateFrom: 'bottom',
       iterations: 1,
       opacity: [0, 1],
     },
     accessibility: {
-      reducedMotion: "replace",
+      reducedMotion: 'replace',
     },
     rationale: {
       short:
-        "Das Modal fährt wie ein Sheet von unten ein und signalisiert damit, " +
-        "dass eine neue Oberfläche geöffnet wird. Die vertikale Bewegung " +
-        "folgt der Konvention mobiler Sheet- und Dialogschichten.",
+        'Das Modal fährt wie ein Sheet von unten ein und signalisiert damit, ' +
+        'dass eine neue Oberfläche geöffnet wird. Die vertikale Bewegung ' +
+        'folgt der Konvention mobiler Sheet- und Dialogschichten.',
       source:
-        "Index (Peirce): Die Richtung verweist hier nicht auf horizontale " +
-        "Vorwärtsnavigation, sondern auf das Erscheinen einer neuen " +
-        "Oberfläche aus dem unteren Bildschirmrand. Direction y von unten: " +
-        "Sheet-Konvention (Apple HIG, Material Design 3). Ease-Out: Ankommen " +
-        "(Zacks & Tversky 2001). " +
-        "Duration 350ms: komplex genug für bewusste Richtungswahrnehmung.",
-      references: ["Peirce1931", "Ware2012", "ZacksTversky2001", "AppleHIG", "MaterialDesign3"],
-      signType: "index",
+        'Index (Peirce): Die Richtung verweist hier nicht auf horizontale ' +
+        'Vorwärtsnavigation, sondern auf das Erscheinen einer neuen ' +
+        'Oberfläche aus dem unteren Bildschirmrand. Direction y von unten: ' +
+        'Sheet-Konvention (Apple HIG, Material Design 3). Ease-Out: Ankommen ' +
+        '(Zacks & Tversky 2001). ' +
+        'Duration 350ms: komplex genug für bewusste Richtungswahrnehmung.',
+      references: [
+        'Peirce1931',
+        'Ware2012',
+        'ZacksTversky2001',
+        'AppleHIG',
+        'MaterialDesign3',
+      ],
+      signType: 'index',
+      semanticContext: {
+        metaphor: {
+          label: 'Eine neue Oberfläche fährt wie ein Sheet ein',
+          visualCue: 'arrival',
+        },
+        primaryReading:
+          'Eine neue Oberfläche erscheint aus einer gerichteten Eintrittsbewegung.',
+        adjacentReadings: [
+          'Öffnung',
+          'neue Aufgabe',
+          'Vordergrundwechsel',
+          'mobile Sheet-Konvention',
+        ],
+        boundaries: [
+          'Bleibt Direction, weil die Eintrittsrichtung die Bedeutung trägt.',
+          'Nicht primär Hierarchy, obwohl das Modal danach Vordergrundpriorität besitzt.',
+        ],
+      },
     },
   },
 
   {
-    id: "modal-direction-exit",
-    component: "modal",
-    dimension: "direction",
-    subcategory: "exit",
+    id: 'modal-direction-exit',
+    component: 'modal',
+    dimension: 'direction',
+    subcategory: 'exit',
     params: {
-      easing: { preset: "easeIn" },
+      easing: { preset: 'easeIn' },
       duration: 280,
-      direction: "y",
-      translateDistance: "self",
-      translateTo: "bottom",
+      direction: 'y',
+      translateDistance: 'self',
+      translateTo: 'bottom',
       iterations: 1,
       opacity: [1, 0],
     },
     accessibility: {
-      reducedMotion: "replace",
+      reducedMotion: 'replace',
     },
     rationale: {
       short:
-        "Das Modal fährt wie ein Sheet nach unten aus. Die komplementäre " +
-        "Richtung zur Einfahrt kommuniziert, dass diese Oberfläche geschlossen wird.",
+        'Das Modal fährt wie ein Sheet nach unten aus. Die komplementäre ' +
+        'Richtung zur Einfahrt kommuniziert, dass diese Oberfläche geschlossen wird.',
       source:
-        "Index (Peirce): komplementäre Sheet-Richtung zu modal-direction-enter. " +
-        "Die Bewegung beschreibt kein horizontales Vorwärts-/Rückwärtsnavigieren, " +
-        "sondern das Schließen einer vertikal eingeführten Oberfläche. " +
-        "Ease-In: Verlassen als Aufbaukurve (Zacks & Tversky 2001). " +
-        "Duration 280ms: kürzer als Enter, das Verlassende ist nicht " +
-        "mehr der Fokus (Head 2016).",
-      references: ["Peirce1931", "ZacksTversky2001", "Head2016", "AppleHIG", "MaterialDesign3"],
-      signType: "index",
+        'Index (Peirce): komplementäre Sheet-Richtung zu modal-direction-enter. ' +
+        'Die Bewegung beschreibt kein horizontales Vorwärts-/Rückwärtsnavigieren, ' +
+        'sondern das Schließen einer vertikal eingeführten Oberfläche. ' +
+        'Ease-In: Verlassen als Aufbaukurve (Zacks & Tversky 2001). ' +
+        'Duration 280ms: kürzer als Enter, das Verlassende ist nicht ' +
+        'mehr der Fokus (Head 2016).',
+      references: [
+        'Peirce1931',
+        'ZacksTversky2001',
+        'Head2016',
+        'AppleHIG',
+        'MaterialDesign3',
+      ],
+      signType: 'index',
+      semanticContext: {
+        metaphor: {
+          label: 'Die Oberfläche fährt aus dem sichtbaren Bereich heraus',
+          visualCue: 'departure',
+        },
+        primaryReading:
+          'Eine Oberfläche wird über eine gerichtete Ausfahrt geschlossen.',
+        adjacentReadings: [
+          'Schließen',
+          'Verlassen',
+          'Fokusverlust',
+          'Rücknahme einer Oberfläche',
+        ],
+        boundaries: [
+          'Bleibt Direction, weil die Ausfahrt die komplementäre Bewegung zum Enter-Mapping ist.',
+          'Nicht primär Hierarchy, weil die Bedeutung über das Verlassen der Oberfläche und nicht über bloße Prioritätsänderung entsteht.',
+        ],
+      },
     },
   },
 
   {
-    id: "modal-direction-backEnter",
-    component: "modal",
-    dimension: "direction",
-    subcategory: "backEnter",
+    id: 'modal-direction-backEnter',
+    component: 'modal',
+    dimension: 'direction',
+    subcategory: 'backEnter',
     params: {
-      easing: { preset: "easeOut" },
+      easing: { preset: 'easeOut' },
       duration: 350,
-      direction: "x",
-      translateDistance: "self",
-      translateFrom: "left",
+      direction: 'x',
+      translateDistance: 'self',
+      translateFrom: 'left',
       iterations: 1,
       opacity: [0, 1],
     },
     accessibility: {
-      reducedMotion: "replace",
+      reducedMotion: 'replace',
     },
     rationale: {
       short:
-        "Das Modal fährt von links ein und macht die vorherige Ebene wieder " +
-        "sichtbar. Die Bewegung unterscheidet sich damit von der vertikalen " +
-        "Sheet-Öffnung des normalen Enter-Mappings.",
+        'Das Modal fährt von links ein und macht die vorherige Ebene wieder ' +
+        'sichtbar. Die Bewegung unterscheidet sich damit von der vertikalen ' +
+        'Sheet-Öffnung des normalen Enter-Mappings.',
       source:
-        "Index (Peirce): Im Navigationskontext verweist die Bewegung von " +
-        "links auf die Rückkehr zur vorherigen Ebene in Schriftkulturen mit " +
-        "Links-rechts-Leserichtung (Ware 2012). Die Richtung ist damit nicht " +
-        "isoliert als universelles Rückwärtszeichen zu verstehen, sondern als " +
-        "Teil eines horizontalen Navigationspaars. Ease-Out: Ankommen " +
-        "(Zacks & Tversky 2001). Komplementär zu modal-direction-backExit. " +
-        "Duration 350ms: identisch zu enter, Richtung trägt die Bedeutung.",
-      references: ["Peirce1931", "Ware2012", "ZacksTversky2001"],
-      signType: "index",
+        'Index (Peirce): Im Navigationskontext verweist die Bewegung von ' +
+        'links auf die Rückkehr zur vorherigen Ebene in Schriftkulturen mit ' +
+        'Links-rechts-Leserichtung (Ware 2012). Die Richtung ist damit nicht ' +
+        'isoliert als universelles Rückwärtszeichen zu verstehen, sondern als ' +
+        'Teil eines horizontalen Navigationspaars. Ease-Out: Ankommen ' +
+        '(Zacks & Tversky 2001). Komplementär zu modal-direction-backExit. ' +
+        'Duration 350ms: identisch zu enter, Richtung trägt die Bedeutung.',
+      references: ['Peirce1931', 'Ware2012', 'ZacksTversky2001'],
+      signType: 'index',
+      semanticContext: {
+        metaphor: {
+          label: 'Rückkehr einer vorherigen Ebene',
+          visualCue: 'returnLayer',
+        },
+        primaryReading:
+          'Eine vorherige Ebene wird im Rahmen einer Rückwärtsnavigation wieder sichtbar.',
+        adjacentReadings: [
+          'räumliche Tiefe',
+          'Rückkehr',
+          'Kontextwechsel',
+          'Hierarchieverschiebung',
+        ],
+        boundaries: [
+          'Bleibt Direction, weil die Bedeutung aus dem horizontalen Navigationspaar entsteht.',
+          'Beschreibt nicht primär, dass ein Element wichtiger wird, sondern dass der Nutzer im Navigationsverlauf zurückgeht.',
+        ],
+      },
     },
   },
 
   {
-    id: "modal-direction-backExit",
-    component: "modal",
-    dimension: "direction",
-    subcategory: "backExit",
+    id: 'modal-direction-backExit',
+    component: 'modal',
+    dimension: 'direction',
+    subcategory: 'backExit',
     params: {
-      easing: { preset: "easeIn" },
+      easing: { preset: 'easeIn' },
       duration: 280,
-      direction: "x",
-      translateDistance: "self",
-      translateTo: "right",
+      direction: 'x',
+      translateDistance: 'self',
+      translateTo: 'right',
       iterations: 1,
       opacity: [1, 0],
     },
     accessibility: {
-      reducedMotion: "replace",
+      reducedMotion: 'replace',
     },
     rationale: {
       short:
-        "Das Modal fährt nach rechts aus und gibt den sichtbaren Kontext für " +
-        "die vorherige Ebene frei. Die Bedeutung entsteht aus dem horizontalen " +
-        "Navigationspaar, nicht aus der Richtung allein.",
+        'Das Modal fährt nach rechts aus und gibt den sichtbaren Kontext für ' +
+        'die vorherige Ebene frei. Die Bedeutung entsteht aus dem horizontalen ' +
+        'Navigationspaar, nicht aus der Richtung allein.',
       source:
-        "Index (Peirce): Die Bewegung nach rechts ist nicht isoliert als " +
-        "allgemeines Rückwärtszeichen zu verstehen, sondern als komplementäre " +
-        "Ausfahrt zu backEnter von links innerhalb einer Rückkehr zur " +
-        "vorherigen Ebene. " +
-        "Anders als modal-direction-exit beschreibt dieses Mapping keine " +
-        "vertikale Sheet-Schließung, sondern eine horizontale Navigationsrichtung. " +
-        "Ware (2012). Ease-In: Verlassen als Aufbaukurve " +
-        "(Zacks & Tversky 2001). Duration 280ms: identisch zu exit.",
-      references: ["Peirce1931", "Ware2012", "ZacksTversky2001"],
-      signType: "index",
+        'Index (Peirce): Die Bewegung nach rechts ist nicht isoliert als ' +
+        'allgemeines Rückwärtszeichen zu verstehen, sondern als komplementäre ' +
+        'Ausfahrt zu backEnter von links innerhalb einer Rückkehr zur ' +
+        'vorherigen Ebene. ' +
+        'Anders als modal-direction-exit beschreibt dieses Mapping keine ' +
+        'vertikale Sheet-Schließung, sondern eine horizontale Navigationsrichtung. ' +
+        'Ware (2012). Ease-In: Verlassen als Aufbaukurve ' +
+        '(Zacks & Tversky 2001). Duration 280ms: identisch zu exit.',
+      references: ['Peirce1931', 'Ware2012', 'ZacksTversky2001'],
+      signType: 'index',
+      semanticContext: {
+        metaphor: {
+          label: 'Aktuelle Ebene weicht für die Rückkehr aus',
+          visualCue: 'returnLayer',
+        },
+        primaryReading:
+          'Die aktuelle Ebene verlässt den sichtbaren Bereich als Teil einer Rückwärtsnavigation.',
+        adjacentReadings: [
+          'Kontextfreigabe',
+          'Rückkehr',
+          'räumliche Schichtung',
+          'Verlassen einer Ebene',
+        ],
+        boundaries: [
+          'Bleibt Direction, weil die Bewegung als komplementäre Ausfahrt zu backEnter gelesen wird.',
+          'Kein Hierarchy-Mapping, weil nicht die visuelle Priorität selbst, sondern die Navigationsrichtung im Vordergrund steht.',
+        ],
+      },
     },
   },
 
@@ -606,76 +913,112 @@ export const mappings: MappingDatabase = [
   // -------------------------------------------------------------------------
 
   {
-    id: "input-feedback-success",
-    component: "input",
-    dimension: "feedback",
-    subcategory: "success",
+    id: 'input-feedback-success',
+    component: 'input',
+    dimension: 'feedback',
+    subcategory: 'success',
     params: {
-      easing: { preset: "easeOut" },
+      easing: { preset: 'easeOut' },
       duration: 175,
       scaleFactor: 0.02, // 1.0 → 1.02 → 1.0
-      scaleMode: "pulse",
+      scaleMode: 'pulse',
       iterations: 1,
     },
     rationale: {
       short:
-        "Die minimale Ausdehnung und die unterstützende Success-Markierung " +
-        "an Feld und Label signalisieren, dass die Eingabe valide ist, " +
-        "ohne den Tippfluss zu unterbrechen.",
+        'Die minimale Ausdehnung und die unterstützende Success-Markierung ' +
+        'an Feld und Label signalisieren, dass die Eingabe valide ist, ' +
+        'ohne den Tippfluss zu unterbrechen.',
       source:
-        "Ikon/Index (Peirce): leichte Expansion als Positivsignal. " +
-        "Die komponentenspezifische Success-Markierung an Border und Label " +
-        "wirkt als visueller Zustands-Signifier (Norman 2013) und unterstützt " +
-        "das Motion-Signal, ohne selbst primärer Bewegungsparameter zu sein. " +
-        "Ease-Out: Abklingen (Zacks & Tversky 2001). Duration 175ms: " +
-        "kürzer als button-feedback-success (250ms), weil Eingabe aktiv " +
-        "sein kann (Head 2016). scaleFactor 0.02: minimal, subtiler als Button.",
-      references: ["Peirce1931", "Norman2013", "ZacksTversky2001", "Head2016"],
-      signType: "icon/index",
+        'Ikon/Index (Peirce): leichte Expansion als Positivsignal. ' +
+        'Die komponentenspezifische Success-Markierung an Border und Label ' +
+        'wirkt als visueller Zustands-Signifier (Norman 2013) und unterstützt ' +
+        'das Motion-Signal, ohne selbst primärer Bewegungsparameter zu sein. ' +
+        'Ease-Out: Abklingen (Zacks & Tversky 2001). Duration 175ms: ' +
+        'kürzer als button-feedback-success (250ms), weil Eingabe aktiv ' +
+        'sein kann (Head 2016). scaleFactor 0.02: minimal, subtiler als Button.',
+      references: ['Peirce1931', 'Norman2013', 'ZacksTversky2001', 'Head2016'],
+      signType: 'icon/index',
+      semanticContext: {
+        metaphor: {
+          label: 'Das Feld bestätigt eine gültige Eingabe',
+          visualCue: 'pulseSignal',
+        },
+        primaryReading:
+          'Die Eingabe ist valide und wird durch eine subtile positive Rückmeldung markiert.',
+        adjacentReadings: [
+          'Validität',
+          'Abschluss',
+          'kurze Bestätigung',
+          'visueller Zustands-Signifier',
+        ],
+        boundaries: [
+          'Bleibt Feedback, weil der Zustand eine Eingabe bewertet.',
+          'Nicht State Change, weil nicht nur Fokus oder Aktivität wechseln, sondern die Validität der Eingabe signalisiert wird.',
+        ],
+      },
     },
   },
 
   {
-    id: "input-feedback-error",
-    component: "input",
-    dimension: "feedback",
-    subcategory: "error",
+    id: 'input-feedback-error',
+    component: 'input',
+    dimension: 'feedback',
+    subcategory: 'error',
     params: {
-      easing: { preset: "sharp" },
+      easing: { preset: 'sharp' },
       duration: 275,
-      direction: "x",
+      direction: 'x',
       translatePx: 5,
       iterations: 1,
       keyframes: {
         values: [0, -5, 5, -5, 5, 0],
-        times:  [0, 0.2, 0.4, 0.6, 0.8, 1.0],
+        times: [0, 0.2, 0.4, 0.6, 0.8, 1.0],
       },
     },
     accessibility: {
-      reducedMotion: "replace",
+      reducedMotion: 'replace',
     },
     rationale: {
       short:
-        "Der reduzierte Shake kommuniziert Ablehnung ohne den Eingabeinhalt " +
-        "visuell zu destabilisieren. Die kürzere Duration respektiert, dass " +
-        "der Nutzer möglicherweise sofort weitertippen möchte.",
+        'Der reduzierte Shake kommuniziert Ablehnung ohne den Eingabeinhalt ' +
+        'visuell zu destabilisieren. Die kürzere Duration respektiert, dass ' +
+        'der Nutzer möglicherweise sofort weitertippen möchte.',
       source:
-        "Index (Peirce): horizontaler Shake als Ablehnungsindex (Ware 2012). " +
-        "translatePx ±5px statt ±8px (Button): Eingabefeld ist breiter, " +
-        "reagiert empfindlicher. Duration 275ms statt 350ms: aktive Eingabe " +
-        "darf nicht blockiert wirken (Head 2016).",
-      references: ["Peirce1931", "Ware2012", "Head2016"],
-      signType: "index",
+        'Index (Peirce): horizontaler Shake als Ablehnungsindex (Ware 2012). ' +
+        'translatePx ±5px statt ±8px (Button): Eingabefeld ist breiter, ' +
+        'reagiert empfindlicher. Duration 275ms statt 350ms: aktive Eingabe ' +
+        'darf nicht blockiert wirken (Head 2016).',
+      references: ['Peirce1931', 'Ware2012', 'Head2016'],
+      signType: 'index',
+      semanticContext: {
+        metaphor: {
+          label: 'Reduziertes Ablehnungssignal am Eingabefeld',
+          visualCue: 'refusalGesture',
+        },
+        primaryReading:
+          'Die Eingabe wird nicht akzeptiert und erhält ein lokales Fehlerfeedback.',
+        adjacentReadings: [
+          'Ablehnung',
+          'Validierungsproblem',
+          'Aufmerksamkeitslenkung',
+          'Handlungskorrektur',
+        ],
+        boundaries: [
+          'Bleibt Feedback, weil eine konkrete Eingabe bewertet wird.',
+          'Nicht Required Field Attention, weil der Shake nicht nur auf fehlende Aufmerksamkeit verweist, sondern eine inhaltliche Ablehnung kommuniziert.',
+        ],
+      },
     },
   },
 
   {
-    id: "input-feedback-warning",
-    component: "input",
-    dimension: "feedback",
-    subcategory: "warning",
+    id: 'input-feedback-warning',
+    component: 'input',
+    dimension: 'feedback',
+    subcategory: 'warning',
     params: {
-      easing: { preset: "easeInOut" },
+      easing: { preset: 'easeInOut' },
       duration: 300,
       opacity: [0, 1],
       iterations: 1,
@@ -684,118 +1027,188 @@ export const mappings: MappingDatabase = [
     },
     rationale: {
       short:
-        "Der Warnhinweis erscheint sanft unterhalb des Felds und kommt mit " +
-        "einem kleinen vertikalen Offset zur Ruhe. Zwei lokale Opacity-Impulse " +
-        "markieren den Hinweis, ohne das Eingabefeld selbst zu bewegen.",
+        'Der Warnhinweis erscheint sanft unterhalb des Felds und kommt mit ' +
+        'einem kleinen vertikalen Offset zur Ruhe. Zwei lokale Opacity-Impulse ' +
+        'markieren den Hinweis, ohne das Eingabefeld selbst zu bewegen.',
       source:
-        "Ikon (Peirce): Opacity-Transition ähnelt physikalischem Erscheinen " +
-        "eines Objekts - ikonische Beziehung. Der kleine y-Offset des " +
-        "Helper-Texts verstärkt dieses Erscheinen als lokales Ankommen, " +
-        "ohne das Eingabefeld selbst zu verschieben. Zwei lokale " +
-        "Opacity-Impulse verstärken die Wahrnehmbarkeit des Warnhinweises, ohne " +
-        "das Feld als Ganzes in ein Aufmerksamkeitssignal zu verwandeln. " +
-        "Die Farbkonvention (Orange/Gelb) des Warnhinweises ist symbolisch, " +
-        "klassifiziert aber die Farbe, nicht die Animation. Ease-In-Out: " +
-        "sanfte, nicht dringende Einblendung. Duration 300ms: Eingabefluss " +
-        "nicht unterbrechen " +
-        "(Head 2016).",
-      references: ["Peirce1931", "Head2016"],
-      signType: "icon",
+        'Ikon (Peirce): Opacity-Transition ähnelt physikalischem Erscheinen ' +
+        'eines Objekts - ikonische Beziehung. Der kleine y-Offset des ' +
+        'Helper-Texts verstärkt dieses Erscheinen als lokales Ankommen, ' +
+        'ohne das Eingabefeld selbst zu verschieben. Zwei lokale ' +
+        'Opacity-Impulse verstärken die Wahrnehmbarkeit des Warnhinweises, ohne ' +
+        'das Feld als Ganzes in ein Aufmerksamkeitssignal zu verwandeln. ' +
+        'Die Farbkonvention (Orange/Gelb) des Warnhinweises ist symbolisch, ' +
+        'klassifiziert aber die Farbe, nicht die Animation. Ease-In-Out: ' +
+        'sanfte, nicht dringende Einblendung. Duration 300ms: Eingabefluss ' +
+        'nicht unterbrechen ' +
+        '(Head 2016).',
+      references: ['Peirce1931', 'Head2016'],
+      signType: 'icon',
+      semanticContext: {
+        metaphor: {
+          label: 'Ein lokaler Warnhinweis erscheint unter dem Feld',
+          visualCue: 'helperMessage',
+        },
+        primaryReading:
+          'Ein Warnhinweis ergänzt das Eingabefeld, ohne das Feld selbst zu destabilisieren.',
+        adjacentReadings: [
+          'Hinweis',
+          'milde Validierung',
+          'lokale Aufmerksamkeit',
+          'unterstützende Erklärung',
+        ],
+        boundaries: [
+          'Bleibt Feedback, weil der Helper-Text eine konkrete Eingabesituation bewertet.',
+          'Nicht reines Attention-Mapping, weil die Bewegung an den Warnhinweis gebunden ist und keine eigenständige Aufforderung des Felds darstellt.',
+        ],
+      },
     },
   },
 
   {
-    id: "input-stateChange-focus",
-    component: "input",
-    dimension: "stateChange",
-    subcategory: "focus",
+    id: 'input-stateChange-focus',
+    component: 'input',
+    dimension: 'stateChange',
+    subcategory: 'focus',
     params: {
-      easing: { preset: "easeOut" },
+      easing: { preset: 'easeOut' },
       duration: 175,
       iterations: 1,
       // Keine Bewegungsfelder: Transition über Border/Shadow im Komponenten-Styling.
     },
     rationale: {
       short:
-        "Die schnelle, abklingende Transition von Fokusrahmen, Feldzustand " +
-        "und Label kommuniziert sofortige Bereitschaft. Der Nutzer sieht, " +
-        "dass das Feld aktiv ist, " +
-        "ohne auf eine Reaktion warten zu müssen.",
+        'Die schnelle, abklingende Transition von Fokusrahmen, Feldzustand ' +
+        'und Label kommuniziert sofortige Bereitschaft. Der Nutzer sieht, ' +
+        'dass das Feld aktiv ist, ' +
+        'ohne auf eine Reaktion warten zu müssen.',
       source:
-        "Ikon (Peirce): Die komponentenspezifische Expansion des Fokusindikators " +
-        "und die Änderung von Border/Label ähnelt einem Herantreten des aktiven " +
-        "Elements. Ease-Out: Ankommen (Zacks & Tversky 2001). " +
-        "Duration 175ms: Nutzer möchte sofort tippen (Head 2016). " +
-        "Accessibility: Fokuszustand muss auch ohne Animation erkennbar " +
-        "sein (WCAG 2.1, 2.4.7).",
-      references: ["Peirce1931", "ZacksTversky2001", "Head2016", "WCAG21"],
-      signType: "icon",
+        'Ikon (Peirce): Die komponentenspezifische Expansion des Fokusindikators ' +
+        'und die Änderung von Border/Label ähnelt einem Herantreten des aktiven ' +
+        'Elements. Ease-Out: Ankommen (Zacks & Tversky 2001). ' +
+        'Duration 175ms: Nutzer möchte sofort tippen (Head 2016). ' +
+        'Accessibility: Fokuszustand muss auch ohne Animation erkennbar ' +
+        'sein (WCAG 2.1, 2.4.7).',
+      references: ['Peirce1931', 'ZacksTversky2001', 'Head2016', 'WCAG21'],
+      signType: 'icon',
+      semanticContext: {
+        metaphor: {
+          label: 'Das Feld wird aktiv und tritt in Eingabebereitschaft',
+          visualCue: 'focusSignal',
+        },
+        primaryReading: 'Das Eingabefeld ist aktiv und bereit für Texteingabe.',
+        adjacentReadings: [
+          'Bereitschaft',
+          'Fokus',
+          'leichte Vordergrundpriorität',
+          'lokale Aufmerksamkeit',
+        ],
+        boundaries: [
+          'Bleibt State Change, weil der Zustand des Felds zwischen inaktiv und aktiv wechselt.',
+          'Kein Feedback, weil keine Eingabe bewertet wird.',
+        ],
+      },
     },
   },
 
   {
-    id: "input-stateChange-blur",
-    component: "input",
-    dimension: "stateChange",
-    subcategory: "blur",
+    id: 'input-stateChange-blur',
+    component: 'input',
+    dimension: 'stateChange',
+    subcategory: 'blur',
     params: {
-      easing: { preset: "easeIn" },
+      easing: { preset: 'easeIn' },
       duration: 210,
       iterations: 1,
       // Border-Rücktransition zum Ruhezustand; im Komponenten-Styling aufgelöst.
     },
     rationale: {
       short:
-        "Das Feld kehrt ruhig in seinen Ausgangszustand zurück. " +
-        "Die leicht verlängerte Rücktransition macht sichtbar, dass " +
-        "der Fokus passiv aus dem Feld zurücktritt.",
+        'Das Feld kehrt ruhig in seinen Ausgangszustand zurück. ' +
+        'Die leicht verlängerte Rücktransition macht sichtbar, dass ' +
+        'der Fokus passiv aus dem Feld zurücktritt.',
       source:
-        "Ikon (Peirce): Rücktransition des Fokusindikators. Ease-In: " +
-        "Zurücktreten als Aufbaukurve (Zacks & Tversky 2001). " +
-        "Duration 210ms: langsam genug, damit die Rückbewegung in der Preview " +
-        "als Zustandswechsel lesbar bleibt. Trotz längerer Dauer wirkt Blur " +
-        "durch Ease-In und Rücknahme von Ring/Label passiver als Focus. " +
-        "Bewusste Asymmetrie zu input-stateChange-focus (Ease-Out): " +
-        "Focus ist aktives Ankommen, Blur ist passives Zurücktreten, " +
-        "keine gleichwertigen Zustände (Norman 2013).",
-      references: ["Peirce1931", "ZacksTversky2001", "Norman2013"],
-      signType: "icon",
+        'Ikon (Peirce): Rücktransition des Fokusindikators. Ease-In: ' +
+        'Zurücktreten als Aufbaukurve (Zacks & Tversky 2001). ' +
+        'Duration 210ms: langsam genug, damit die Rückbewegung in der Preview ' +
+        'als Zustandswechsel lesbar bleibt. Trotz längerer Dauer wirkt Blur ' +
+        'durch Ease-In und Rücknahme von Ring/Label passiver als Focus. ' +
+        'Bewusste Asymmetrie zu input-stateChange-focus (Ease-Out): ' +
+        'Focus ist aktives Ankommen, Blur ist passives Zurücktreten, ' +
+        'keine gleichwertigen Zustände (Norman 2013).',
+      references: ['Peirce1931', 'ZacksTversky2001', 'Norman2013'],
+      signType: 'icon',
+      semanticContext: {
+        metaphor: {
+          label: 'Das Feld tritt aus der Eingabebereitschaft zurück',
+          visualCue: 'focusSignal',
+        },
+        primaryReading: 'Das Eingabefeld verlässt den aktiven Fokuszustand.',
+        adjacentReadings: [
+          'Fokusverlust',
+          'Rückkehr zum Ruhezustand',
+          'passiver Zustandswechsel',
+          'Ende der Eingabebereitschaft',
+        ],
+        boundaries: [
+          'Bleibt State Change, weil der Fokuszustand zurückgesetzt wird.',
+          'Kein Hierarchy-Mapping, weil das Feld nicht als Ebene zurückgestuft wird.',
+        ],
+      },
     },
   },
 
   {
-    id: "input-attention-requiredField",
-    component: "input",
-    dimension: "attention",
-    subcategory: "requiredField",
+    id: 'input-attention-requiredField',
+    component: 'input',
+    dimension: 'attention',
+    subcategory: 'requiredField',
     params: {
-      easing: { preset: "easeInOut" },
+      easing: { preset: 'easeInOut' },
       duration: 450,
       scaleFactor: 0.015, // 1.0 → 1.015 → 1.0
-      scaleMode: "pulse",
+      scaleMode: 'pulse',
       iterations: 3,
     },
     accessibility: {
-      reducedMotion: "shorten",
+      reducedMotion: 'shorten',
     },
     rationale: {
       short:
-        "Das Feld pulsiert dreimal subtil und lenkt die Aufmerksamkeit auf " +
-        "eine ausstehende Pflichtangabe. Die Wiederholung macht den Zustand " +
-        "wahrnehmbar, ohne die laufende Orientierung im Formular zu unterbrechen.",
+        'Das Feld pulsiert dreimal subtil und lenkt die Aufmerksamkeit auf ' +
+        'eine ausstehende Pflichtangabe. Die Wiederholung macht den Zustand ' +
+        'wahrnehmbar, ohne die laufende Orientierung im Formular zu unterbrechen.',
       source:
-        "Index (Peirce): wiederholte Bewegung verweist auf einen ausstehenden " +
-        "Zustand, der Aufmerksamkeit benötigt. Attention-Dimension: Das Signal " +
-        "markiert ein konkretes Pflichtfeld als handlungsrelevant, statt eine " +
-        "Eingabe inhaltlich zu bewerten. Bartram et al. (2003) zeigen, dass " +
-        "einfache Bewegungsattribute Aufmerksamkeit zuverlässig lenken können. " +
-        "Ease-In-Out erzeugt ein gleichmäßiges, nicht abruptes Signal; drei " +
-        "Iterationen machen die Aufmerksamkeitspflicht erkennbar, ohne eine " +
-        "dauerhafte Ablenkung zu erzeugen. Duration 450ms pro Zyklus bleibt " +
-        "im Rahmen einer wahrnehmbaren, aber zurückhaltenden Microinteraction " +
-        "(Head 2016).",
-      references: ["Peirce1931", "BartramWareCalvert2003", "Head2016"],
-      signType: "index",
+        'Index (Peirce): wiederholte Bewegung verweist auf einen ausstehenden ' +
+        'Zustand, der Aufmerksamkeit benötigt. Attention-Dimension: Das Signal ' +
+        'markiert ein konkretes Pflichtfeld als handlungsrelevant, statt eine ' +
+        'Eingabe inhaltlich zu bewerten. Bartram et al. (2003) zeigen, dass ' +
+        'einfache Bewegungsattribute Aufmerksamkeit zuverlässig lenken können. ' +
+        'Ease-In-Out erzeugt ein gleichmäßiges, nicht abruptes Signal; drei ' +
+        'Iterationen machen die Aufmerksamkeitspflicht erkennbar, ohne eine ' +
+        'dauerhafte Ablenkung zu erzeugen. Duration 450ms pro Zyklus bleibt ' +
+        'im Rahmen einer wahrnehmbaren, aber zurückhaltenden Microinteraction ' +
+        '(Head 2016).',
+      references: ['Peirce1931', 'BartramWareCalvert2003', 'Head2016'],
+      signType: 'index',
+      semanticContext: {
+        metaphor: {
+          label: 'Das Feld macht sich lokal bemerkbar',
+          visualCue: 'pulseSignal',
+        },
+        primaryReading:
+          'Ein konkretes Feld benötigt Aufmerksamkeit, weil eine Pflichtangabe aussteht.',
+        adjacentReadings: [
+          'Validierungsproblem',
+          'indirektes Fehlerfeedback',
+          'Handlungsaufforderung',
+          'lokaler Hinweis',
+        ],
+        boundaries: [
+          'Bleibt Attention, weil nicht die gesamte Formularaktion bewertet wird.',
+          'Die Bewegung sagt primär nicht, dass die Eingabe falsch ist, sondern dass an dieser Stelle noch etwas fehlt.',
+        ],
+      },
     },
   },
 
@@ -804,66 +1217,102 @@ export const mappings: MappingDatabase = [
   // -------------------------------------------------------------------------
 
   {
-    id: "skeleton-attention-loading",
-    component: "skeleton",
-    dimension: "attention",
-    subcategory: "loading",
+    id: 'skeleton-attention-loading',
+    component: 'skeleton',
+    dimension: 'attention',
+    subcategory: 'loading',
     params: {
-      easing: { preset: "linear" },
+      easing: { preset: 'linear' },
       duration: 1500,
-      direction: "x",
+      direction: 'x',
       trackFactor: 1.0, // volle komponenteneigene Shimmer-Strecke
       iterations: Infinity,
     },
     accessibility: {
-      reducedMotion: "static",
+      reducedMotion: 'static',
     },
     rationale: {
       short:
-        "Der Shimmer bewegt sich mit konstanter Geschwindigkeit von links " +
-        "nach rechts über den Platzhalter. Es besteht kein natürlicher " +
-        "Zusammenhang zwischen dieser Bewegung und dem Ladevorgang. Die " +
-        "Bedeutung entsteht ausschließlich durch Konvention, die sich " +
-        "durch den verbreiteten Einsatz in digitalen Interfaces etabliert hat.",
+        'Der Shimmer bewegt sich mit konstanter Geschwindigkeit von links ' +
+        'nach rechts über den Platzhalter. Es besteht kein natürlicher ' +
+        'Zusammenhang zwischen dieser Bewegung und dem Ladevorgang. Die ' +
+        'Bedeutung entsteht ausschließlich durch Konvention, die sich ' +
+        'durch den verbreiteten Einsatz in digitalen Interfaces etabliert hat.',
       source:
-        "Symbol (Peirce): Die Shimmer-Animation hat keine ikonische Ähnlichkeit " +
-        "mit einem Ladeprozess und keine indexikalische Assoziation damit. " +
-        "Die Bedeutung ist rein konventionell (Chandler 2007, S. 36). " +
-        "Lineares Easing: konstante Geschwindigkeit repräsentiert einen " +
-        "kontinuierlichen Prozess ohne identifizierbare Phasenstruktur " +
-        "(Zacks & Tversky 2001). Linear ist der einzige semantisch " +
-        "begründete Einsatz dieses Presets im Framework. Accessibility: " +
-        "Der endlose Shimmer muss bei prefers-reduced-motion reduzierbar oder " +
-        "durch einen statischen Ladezustand ersetzbar sein (WCAG 2.1 SC 2.3.3).",
-      references: ["Peirce1931", "Chandler2007", "ZacksTversky2001", "WCAG21"],
-      signType: "symbol",
+        'Symbol (Peirce): Die Shimmer-Animation hat keine ikonische Ähnlichkeit ' +
+        'mit einem Ladeprozess und keine indexikalische Assoziation damit. ' +
+        'Die Bedeutung ist rein konventionell (Chandler 2007, S. 36). ' +
+        'Lineares Easing: konstante Geschwindigkeit repräsentiert einen ' +
+        'kontinuierlichen Prozess ohne identifizierbare Phasenstruktur ' +
+        '(Zacks & Tversky 2001). Linear ist der einzige semantisch ' +
+        'begründete Einsatz dieses Presets im Framework. Accessibility: ' +
+        'Der endlose Shimmer muss bei prefers-reduced-motion reduzierbar oder ' +
+        'durch einen statischen Ladezustand ersetzbar sein (WCAG 2.1 SC 2.3.3).',
+      references: ['Peirce1931', 'Chandler2007', 'ZacksTversky2001', 'WCAG21'],
+      signType: 'symbol',
+      semanticContext: {
+        metaphor: {
+          label: 'Wandernder Lichtstreifen als Ladezeichen',
+          visualCue: 'shimmerSignal',
+        },
+        primaryReading:
+          'Ein Ladezustand ist aktiv und Inhalt ist noch nicht verfügbar.',
+        adjacentReadings: [
+          'Systemaktivität',
+          'temporärer Platzhalter',
+          'Wartezustand',
+          'technisches Fortschrittssignal',
+        ],
+        boundaries: [
+          'Bleibt Attention, weil das Mapping einen laufenden Zustand sichtbar hält, ohne ein Ergebnis zu kommunizieren.',
+          'Bleibt als Symbol eingeordnet, weil die Bedeutung des Shimmers durch UI-Konvention gelernt ist.',
+        ],
+      },
     },
   },
 
   {
-    id: "skeleton-attention-resolved",
-    component: "skeleton",
-    dimension: "attention",
-    subcategory: "resolved",
+    id: 'skeleton-attention-resolved',
+    component: 'skeleton',
+    dimension: 'attention',
+    subcategory: 'resolved',
     params: {
-      easing: { preset: "easeOut" },
+      easing: { preset: 'easeOut' },
       duration: 350,
       iterations: 1,
       opacity: [1, 0],
     },
     rationale: {
       short:
-        "Der Skeleton blendet aus, sobald der Inhalt eintrifft. Das Ausblenden " +
-        "ähnelt dem physikalischen Verschwinden eines Platzhalters und " +
-        "signalisiert, dass der Ladeprozess abgeschlossen ist.",
+        'Der Skeleton blendet aus, sobald der Inhalt eintrifft. Das Ausblenden ' +
+        'ähnelt dem physikalischen Verschwinden eines Platzhalters und ' +
+        'signalisiert, dass der Ladeprozess abgeschlossen ist.',
       source:
-        "Ikon (Peirce): Opazitätsreduktion ähnelt physikalischem Verblassen " +
-        "und Verschwinden (Chandler 2007). Ease-Out: abklingende Kurve als " +
-        "Signal für Abschluss (Zacks & Tversky 2001). Duration 350ms: " +
-        "wahrnehmbar, nicht abrupt. Als Ikon klassifiziert, nicht als Symbol: " +
-        "Das Ausblenden hat eine natürliche, nicht-konventionelle Grundlage.",
-      references: ["Peirce1931", "Chandler2007", "ZacksTversky2001"],
-      signType: "icon",
+        'Ikon (Peirce): Opazitätsreduktion ähnelt physikalischem Verblassen ' +
+        'und Verschwinden (Chandler 2007). Ease-Out: abklingende Kurve als ' +
+        'Signal für Abschluss (Zacks & Tversky 2001). Duration 350ms: ' +
+        'wahrnehmbar, nicht abrupt. Als Ikon klassifiziert, nicht als Symbol: ' +
+        'Das Ausblenden hat eine natürliche, nicht-konventionelle Grundlage.',
+      references: ['Peirce1931', 'Chandler2007', 'ZacksTversky2001'],
+      signType: 'icon',
+      semanticContext: {
+        metaphor: {
+          label: 'Der Platzhalter löst sich auf',
+          visualCue: 'fadeResolve',
+        },
+        primaryReading:
+          'Der Platzhalter verschwindet, weil Inhalt angekommen ist.',
+        adjacentReadings: [
+          'Abschluss',
+          'Verfügbarkeit',
+          'Übergang von Systemzustand zu Inhalt',
+          'Ende eines Wartezustands',
+        ],
+        boundaries: [
+          'Bleibt im Skeleton-Kontext Attention, weil es den Abschluss eines zuvor aufmerksamkeitsrelevanten Ladezustands markiert.',
+          'Kein allgemeines Success-Feedback, weil keine direkte Nutzeraktion bestätigt wird.',
+        ],
+      },
     },
   },
 ];

--- a/prototyp/src/editor/SemanticContextPanel.tsx
+++ b/prototyp/src/editor/SemanticContextPanel.tsx
@@ -1,0 +1,140 @@
+import {
+  motion,
+  useReducedMotion,
+  type Transition,
+  type Variants,
+} from 'framer-motion';
+import type { SemanticContext, VisualCueId } from '../framework/types';
+import { lucidePlaceholderByVisualCueId } from '../framework/visualCues';
+
+type SemanticContextPanelProps = {
+  semanticContext: SemanticContext;
+};
+
+const visualCueLabels: Record<VisualCueId, string> = {
+  refusalGesture: 'Ablehnungsgeste',
+  pulseSignal: 'Bedeutungsimpuls',
+  toggleTravel: 'Schalterbewegung',
+  arrival: 'Ankunft',
+  departure: 'Verlassen',
+  nudgeSignal: 'Hinweisstoß',
+  returnLayer: 'Rückkehrende Ebene',
+  foreground: 'Vordergrund',
+  backgroundRecede: 'Zurücktreten',
+  focusSignal: 'Fokussignal',
+  helperMessage: 'Hilfstext',
+  shimmerSignal: 'Shimmer',
+  fadeResolve: 'Auflösung',
+};
+
+const visualCueMarks: Record<VisualCueId, string> = {
+  refusalGesture: 'NO',
+  pulseSignal: '))',
+  toggleTravel: 'ON',
+  arrival: 'IN',
+  departure: 'OUT',
+  nudgeSignal: '!',
+  returnLayer: '<-',
+  foreground: 'FG',
+  backgroundRecede: 'BG',
+  focusSignal: '[]',
+  helperMessage: '?',
+  shimmerSignal: '//',
+  fadeResolve: '..',
+};
+
+const semanticContextVariants: Variants = {
+  hidden: { height: 0, opacity: 0 },
+  visible: { height: 'auto', opacity: 1 },
+};
+
+const semanticContextTransition: Transition = {
+  height: {
+    duration: 0.26,
+    ease: [0.4, 0, 0.2, 1],
+  },
+  opacity: {
+    duration: 0.16,
+    ease: [0.4, 0, 0.2, 1],
+  },
+};
+
+function getVisualCueList(visualCue: VisualCueId | VisualCueId[]) {
+  return Array.isArray(visualCue) ? visualCue : [visualCue];
+}
+
+function SemanticContextPanel({ semanticContext }: SemanticContextPanelProps) {
+  const visualCues = getVisualCueList(semanticContext.metaphor.visualCue);
+  const shouldReduceMotion = useReducedMotion();
+
+  return (
+    <motion.div
+      className="semantic-context-motion-shell"
+      animate={shouldReduceMotion ? { opacity: 1 } : 'visible'}
+      exit={shouldReduceMotion ? { opacity: 0 } : 'hidden'}
+      initial={shouldReduceMotion ? false : 'hidden'}
+      transition={
+        shouldReduceMotion ? { duration: 0 } : semanticContextTransition
+      }
+      variants={semanticContextVariants}
+    >
+      <section className="editor-panel editor-semantic-context-panel">
+        <div className="editor-panel-header">
+          <p className="editor-panel-title">Semantischer Möglichkeitsraum</p>
+          <span className="semantic-context-field">
+            rationale.semanticContext
+          </span>
+        </div>
+
+        <div className="semantic-context-head">
+          <div aria-label="Visuelle Cues" className="semantic-context-cues">
+            {visualCues.map((cue) => {
+              const placeholder = lucidePlaceholderByVisualCueId[cue];
+
+              return (
+                <span
+                  aria-label={`${visualCueLabels[cue]} (${placeholder.lucideIcon})`}
+                  className={`semantic-context-cue cue-${cue}`}
+                  key={cue}
+                  title={`${visualCueLabels[cue]} · Lucide-Platzhalter: ${placeholder.lucideIcon}`}
+                >
+                  <span aria-hidden="true">{visualCueMarks[cue]}</span>
+                </span>
+              );
+            })}
+          </div>
+
+          <div className="semantic-context-metaphor">
+            <span>Bildhafte Lesart</span>
+            <strong>{semanticContext.metaphor.label}</strong>
+          </div>
+        </div>
+
+        <p className="semantic-context-primary">
+          <span>Primäre Lesart</span>
+          {semanticContext.primaryReading}
+        </p>
+
+        <div
+          aria-label="Angrenzende Lesarten"
+          className="semantic-reading-chips"
+        >
+          {semanticContext.adjacentReadings.map((reading) => (
+            <span key={reading}>{reading}</span>
+          ))}
+        </div>
+
+        <details className="semantic-boundaries">
+          <summary>Möglichkeitsraum und Abgrenzung</summary>
+          <ul>
+            {semanticContext.boundaries.map((boundary) => (
+              <li key={boundary}>{boundary}</li>
+            ))}
+          </ul>
+        </details>
+      </section>
+    </motion.div>
+  );
+}
+
+export default SemanticContextPanel;

--- a/prototyp/src/framework/types.ts
+++ b/prototyp/src/framework/types.ts
@@ -24,12 +24,12 @@
  *            ohne ikonische oder indexikalische Grundlage (Chandler 2007, S. 36).
  */
 export const COMPONENT_IDS = [
-  "button",
-  "toggle",
-  "toast",
-  "modal",
-  "input",
-  "skeleton",
+  'button',
+  'toggle',
+  'toast',
+  'modal',
+  'input',
+  'skeleton',
 ] as const;
 
 export type ComponentId = (typeof COMPONENT_IDS)[number];
@@ -48,11 +48,11 @@ export type ComponentId = (typeof COMPONENT_IDS)[number];
  * attention   – Element lenkt Aufmerksamkeit ohne vorherige Nutzeraktion
  */
 export const DIMENSIONS = [
-  "feedback",
-  "stateChange",
-  "direction",
-  "hierarchy",
-  "attention",
+  'feedback',
+  'stateChange',
+  'direction',
+  'hierarchy',
+  'attention',
 ] as const;
 
 export type Dimension = (typeof DIMENSIONS)[number];
@@ -61,39 +61,39 @@ export type Dimension = (typeof DIMENSIONS)[number];
 // Subkategorien je Dimension
 // ---------------------------------------------------------------------------
 
-export const FEEDBACK_SUBCATEGORIES = ["success", "error", "warning"] as const;
+export const FEEDBACK_SUBCATEGORIES = ['success', 'error', 'warning'] as const;
 export type FeedbackSubcategory = (typeof FEEDBACK_SUBCATEGORIES)[number];
 
 export const STATE_CHANGE_SUBCATEGORIES = [
-  "toggleOn",
-  "toggleOff",
-  "focus",
-  "blur",
+  'toggleOn',
+  'toggleOff',
+  'focus',
+  'blur',
 ] as const;
 export type StateChangeSubcategory =
   (typeof STATE_CHANGE_SUBCATEGORIES)[number];
 
 export const DIRECTION_SUBCATEGORIES = [
-  "enter",      // Element erscheint als neue/vorwärts gerichtete Ebene
-  "exit",       // Aktuelle Ebene wird in Vorwärtsnavigation verlassen
-  "backEnter",  // Vorherige Ebene erscheint bei Rückwärtsnavigation
-  "backExit",   // Aktuelle Ebene wird in Rückwärtsnavigation verlassen
+  'enter', // Element erscheint als neue/vorwärts gerichtete Ebene
+  'exit', // Aktuelle Ebene wird in Vorwärtsnavigation verlassen
+  'backEnter', // Vorherige Ebene erscheint bei Rückwärtsnavigation
+  'backExit', // Aktuelle Ebene wird in Rückwärtsnavigation verlassen
 ] as const;
 export type DirectionSubcategory = (typeof DIRECTION_SUBCATEGORIES)[number];
 
 export const HIERARCHY_SUBCATEGORIES = [
-  "toForeground", // Element wird zum primären Inhalt
-  "toBackground", // Element verliert Vordergrundpriorität und tritt aus dem Fokus zurück
+  'toForeground', // Element wird zum primären Inhalt
+  'toBackground', // Element verliert Vordergrundpriorität und tritt aus dem Fokus zurück
 ] as const;
 export type HierarchySubcategory = (typeof HIERARCHY_SUBCATEGORIES)[number];
 
 export const ATTENTION_SUBCATEGORIES = [
-  "oneShot",       // Einmaliges Aufmerksamkeitssignal, endet automatisch
-  "persistent",    // Wiederholendes Signal bis zur Nutzeraktion (unendliche Iterationen)
-  "warning",       // Systeminitiiertes Warnsignal, endet nach N Iterationen
-  "requiredField", // Pflichtfeld fordert Aufmerksamkeit nach fehlgeschlagenem Absenden
-  "loading",       // Skeleton-Shimmer: kontinuierliches Prozesssignal (Symbol)
-  "resolved",      // Skeleton-Ausblenden: Inhalt ist angekommen (Ikon)
+  'oneShot', // Einmaliges Aufmerksamkeitssignal, endet automatisch
+  'persistent', // Wiederholendes Signal bis zur Nutzeraktion (unendliche Iterationen)
+  'warning', // Systeminitiiertes Warnsignal, endet nach N Iterationen
+  'requiredField', // Pflichtfeld fordert Aufmerksamkeit nach fehlgeschlagenem Absenden
+  'loading', // Skeleton-Shimmer: kontinuierliches Prozesssignal (Symbol)
+  'resolved', // Skeleton-Ausblenden: Inhalt ist angekommen (Ikon)
 ] as const;
 export type AttentionSubcategory = (typeof ATTENTION_SUBCATEGORIES)[number];
 
@@ -139,12 +139,12 @@ export const SUBCATEGORIES_BY_DIMENSION = {
  * spring       (Framer Motion spring) – physikalisches Gewicht, Follow-Through
  */
 export type EasingPreset =
-  | "easeOut"
-  | "easeIn"
-  | "easeInOut"
-  | "sharp"
-  | "linear"
-  | "spring";
+  | 'easeOut'
+  | 'easeIn'
+  | 'easeInOut'
+  | 'sharp'
+  | 'linear'
+  | 'spring';
 
 /**
  * Die Easing-Definition, die in Animationsparametern verwendet wird.
@@ -163,13 +163,16 @@ export type EasingValue =
  * Für "spring" ist der Wert nur ein CSS-/Fallback-Platzhalter.
  * Framer Motion muss stattdessen springConfig verwenden.
  */
-export const EASING_CURVES: Record<EasingPreset, [number, number, number, number]> = {
-  easeOut:   [0.0, 0.0, 0.2, 1.0],
-  easeIn:    [0.4, 0.0, 1.0, 1.0],
+export const EASING_CURVES: Record<
+  EasingPreset,
+  [number, number, number, number]
+> = {
+  easeOut: [0.0, 0.0, 0.2, 1.0],
+  easeIn: [0.4, 0.0, 1.0, 1.0],
   easeInOut: [0.4, 0.0, 0.2, 1.0],
-  sharp:     [0.4, 0.0, 0.6, 1.0],
-  linear:    [0.0, 0.0, 1.0, 1.0],
-  spring:    [0.0, 0.0, 0.2, 1.0], // Platzhalter; spring verwendet die Framer-Motion-Spring-Konfiguration
+  sharp: [0.4, 0.0, 0.6, 1.0],
+  linear: [0.0, 0.0, 1.0, 1.0],
+  spring: [0.0, 0.0, 0.2, 1.0], // Platzhalter; spring verwendet die Framer-Motion-Spring-Konfiguration
 };
 
 // ---------------------------------------------------------------------------
@@ -181,9 +184,9 @@ export const EASING_CURVES: Record<EasingPreset, [number, number, number, number
  * Wird nur verwendet wenn EasingValue { preset: "spring" } ist.
  */
 export interface SpringConfig {
-  stiffness: number;  // Standard 100 – höher = reaktionsschneller
-  damping: number;    // Standard 10  – niedriger = mehr Schwingung
-  mass: number;       // Standard 1   – höher = schwereres Gefühl
+  stiffness: number; // Standard 100 – höher = reaktionsschneller
+  damping: number; // Standard 10  – niedriger = mehr Schwingung
+  mass: number; // Standard 1   – höher = schwereres Gefühl
 }
 
 // ---------------------------------------------------------------------------
@@ -232,7 +235,7 @@ export interface MotionPhase {
    * Erforderlich wenn translatePx, translateDistance, translateFrom,
    * translateTo oder keyframes gesetzt ist.
    */
-  direction?: "x" | "y";
+  direction?: 'x' | 'y';
 
   /** Pixel-Versatz für translatorische Phasen */
   translatePx?: number;
@@ -267,20 +270,20 @@ export interface MotionPhase {
  * Wird nur für Enter-/Exit-Bewegungen verwendet, bei denen der konkrete Pixelwert
  * erst im Komponenten-Rendering bekannt ist.
  */
-export type TranslationEdge = "left" | "right" | "top" | "bottom";
+export type TranslationEdge = 'left' | 'right' | 'top' | 'bottom';
 
 /**
  * Distanz einer größenabhängigen Translation.
  * "self" bedeutet: volle Breite oder Höhe des animierten Elements, abhängig von direction.
  */
-export type TranslationDistance = "self";
+export type TranslationDistance = 'self';
 
 /**
  * Explizite Interpretation von scaleFactor.
  * scaleFactor bleibt dabei ein positives Intensitätsdelta; scaleMode legt fest,
  * ob daraus ein Pulse, Scale-In oder Scale-Out entsteht.
  */
-export type ScaleMode = "pulse" | "scaleIn" | "scaleOut";
+export type ScaleMode = 'pulse' | 'scaleIn' | 'scaleOut';
 
 // ---------------------------------------------------------------------------
 // Animationsparameter
@@ -346,7 +349,7 @@ export interface AnimationParams {
    * Die konkrete Herkunft/Zielrichtung wird bei größenabhängigen Bewegungen
    * über translateFrom und translateTo angegeben.
    */
-  direction?: "x" | "y";
+  direction?: 'x' | 'y';
 
   /**
    * Pixel-Versatz für translatorische Animationen (Shake, Slide).
@@ -470,11 +473,7 @@ export interface AnimationParams {
  * replace  – problematische Bewegung wird durch weniger bewegungsintensive Darstellung ersetzt
  * static   – Bewegung entfällt; ein statischer Zustand trägt die Information
  */
-export type ReducedMotionStrategy =
-  | "none"
-  | "shorten"
-  | "replace"
-  | "static";
+export type ReducedMotionStrategy = 'none' | 'shorten' | 'replace' | 'static';
 
 /**
  * Accessibility-Metadaten für einen Mapping-Eintrag.
@@ -498,7 +497,7 @@ export interface MappingAccessibility {
  * symbol     – Bedeutung der Animation ist rein konventionell (erlernt)
  * icon/index – dominanter Aspekt ist ikonisch mit einem indexikalischen Anteil
  */
-export type SignType = "icon" | "index" | "symbol" | "icon/index";
+export type SignType = 'icon' | 'index' | 'symbol' | 'icon/index';
 
 /**
  * Maschinenlesbare Referenzschlüssel für wissenschaftliche und technische Quellen.
@@ -506,19 +505,66 @@ export type SignType = "icon" | "index" | "symbol" | "icon/index";
  * zusätzlich eine konsistente Nachvollziehbarkeit über alle Mapping-Einträge.
  */
 export type ReferenceKey =
-  | "Peirce1931"
-  | "Chandler2007"
-  | "Norman2013"
-  | "Ware2012"
-  | "ZacksTversky2001"
-  | "BartramWareCalvert2003"
-  | "ThomasJohnston1981"
-  | "ChangUngar1993"
-  | "HeerRobertson2007"
-  | "Head2016"
-  | "MaterialDesign3"
-  | "AppleHIG"
-  | "WCAG21";
+  | 'Peirce1931'
+  | 'Chandler2007'
+  | 'Norman2013'
+  | 'Ware2012'
+  | 'ZacksTversky2001'
+  | 'BartramWareCalvert2003'
+  | 'ThomasJohnston1981'
+  | 'ChangUngar1993'
+  | 'HeerRobertson2007'
+  | 'Head2016'
+  | 'MaterialDesign3'
+  | 'AppleHIG'
+  | 'WCAG21';
+
+/**
+ * Kleine semantische Hinweiszeichen für die bildhafte Lesart eines Mappings.
+ * Diese IDs beschreiben keine konkreten Icon-Komponenten und keine Animation.
+ * Sie werden später im Editor auf Glyphs oder Icon-Platzhalter abgebildet.
+ */
+export const VISUAL_CUE_IDS = [
+  'refusalGesture',
+  'pulseSignal',
+  'toggleTravel',
+  'arrival',
+  'departure',
+  'nudgeSignal',
+  'returnLayer',
+  'foreground',
+  'backgroundRecede',
+  'focusSignal',
+  'helperMessage',
+  'shimmerSignal',
+  'fadeResolve',
+] as const;
+
+export type VisualCueId = (typeof VISUAL_CUE_IDS)[number];
+
+/**
+ * Bildhafte Lesart einer Bewegung.
+ * Das Label erklärt die Wahrnehmungs- oder Gestenmetapher sprachlich.
+ * visualCue verweist auf ein kleines erklärendes Glyph, nicht auf die
+ * technische Animation selbst.
+ */
+export interface SemanticMetaphor {
+  label: string;
+  visualCue: VisualCueId | VisualCueId[];
+}
+
+/**
+ * Reflexionsebene für Graustufen und Möglichkeitsräume.
+ * primaryReading hält die dominante semantische Lesart fest.
+ * adjacentReadings beschreibt nahe Bedeutungen, die mitgelesen werden können.
+ * boundaries grenzt die primäre Zuordnung gegen ähnliche Lesarten ab.
+ */
+export interface SemanticContext {
+  metaphor: SemanticMetaphor;
+  primaryReading: string;
+  adjacentReadings: string[];
+  boundaries: string[];
+}
 
 /**
  * Die zweischichtige Begründung für jeden Mapping-Eintrag.
@@ -537,12 +583,19 @@ export type ReferenceKey =
  *           und spätere Export-/Details-Ansichten.
  *
  * signType: Der dominante Peirce'sche Zeichentyp für dieses Mapping.
+ *
+ * semanticContext:
+ *           Ergänzende Reflexionsebene aus bildhafter Lesart, visuellem Cue,
+ *           primärer Lesart, angrenzenden Lesarten und Abgrenzungen. Dieses
+ *           Feld steuert weder Preview noch Export, sondern unterstützt die
+ *           begründete Auswahl im Editor und die wissenschaftliche Einordnung.
  */
 export interface Rationale {
   short: string;
   source: string;
   references: ReferenceKey[];
   signType: SignType;
+  semanticContext: SemanticContext;
 }
 
 // ---------------------------------------------------------------------------

--- a/prototyp/src/framework/validation.test.ts
+++ b/prototyp/src/framework/validation.test.ts
@@ -17,10 +17,12 @@ import {
   COMPONENT_IDS,
   DIMENSIONS,
   SUBCATEGORIES_BY_DIMENSION,
+  VISUAL_CUE_IDS,
   type Dimension,
   type Subcategory,
 } from './types';
 import { validateMappingDatabase, validateMappingEntry } from './validation';
+import { lucidePlaceholderByVisualCueId } from './visualCues';
 
 function sortedKeys(record: Record<string, unknown>) {
   return Object.keys(record).sort();
@@ -51,9 +53,7 @@ describe('framework mapping database validation', () => {
     expect(entry?.id).toBe('button-feedback-error');
     expect(entry?.params.easing).toEqual({ preset: 'sharp' });
     expect(entry?.params.direction).toBe('x');
-    expect(entry?.params.keyframes?.values).toEqual([
-      0, -8, 8, -8, 8, -4, 0,
-    ]);
+    expect(entry?.params.keyframes?.values).toEqual([0, -8, 8, -8, 8, -4, 0]);
     expect(entry?.rationale.source).toContain('Peirce');
     expect(entry?.rationale.references.length).toBeGreaterThan(0);
   });
@@ -108,6 +108,36 @@ describe('framework mapping database validation', () => {
     ]);
   });
 
+  it('keeps semantic context complete for every mapping entry', () => {
+    for (const entry of mappings) {
+      const { semanticContext } = entry.rationale;
+      const visualCues = Array.isArray(semanticContext.metaphor.visualCue)
+        ? semanticContext.metaphor.visualCue
+        : [semanticContext.metaphor.visualCue];
+
+      expect(semanticContext.metaphor.label.trim()).not.toBe('');
+      expect(semanticContext.primaryReading.trim()).not.toBe('');
+      expect(semanticContext.adjacentReadings.length).toBeGreaterThan(0);
+      expect(semanticContext.boundaries.length).toBeGreaterThan(0);
+      expect(visualCues.length).toBeGreaterThan(0);
+
+      for (const cue of visualCues) {
+        expect(VISUAL_CUE_IDS).toContain(cue);
+      }
+    }
+  });
+
+  it('keeps visual cue placeholders aligned with framework cue ids', () => {
+    expect(sortedKeys(lucidePlaceholderByVisualCueId)).toEqual(
+      [...VISUAL_CUE_IDS].sort(),
+    );
+
+    for (const placeholder of Object.values(lucidePlaceholderByVisualCueId)) {
+      expect(placeholder.lucideIcon.trim()).not.toBe('');
+      expect(placeholder.note.trim()).not.toBe('');
+    }
+  });
+
   it('requires scaleMode when scaleFactor is used', () => {
     const entry = getMappingById('button-feedback-success');
 
@@ -156,6 +186,48 @@ describe('framework mapping database validation', () => {
 
     expect(errors).toContain(
       'skeleton-attention-loading: repeated or endless motion requires accessibility.reducedMotion',
+    );
+  });
+
+  it('requires semantic context on mapping rationales', () => {
+    const entry = getMappingById('button-feedback-success');
+
+    expect(entry).not.toBeNull();
+
+    const errors = validateMappingEntry({
+      ...entry!,
+      rationale: {
+        ...entry!.rationale,
+        semanticContext: undefined as never,
+      },
+    });
+
+    expect(errors).toContain(
+      'button-feedback-success: missing rationale.semanticContext',
+    );
+  });
+
+  it('rejects unknown semantic visual cues', () => {
+    const entry = getMappingById('button-feedback-success');
+
+    expect(entry).not.toBeNull();
+
+    const errors = validateMappingEntry({
+      ...entry!,
+      rationale: {
+        ...entry!.rationale,
+        semanticContext: {
+          ...entry!.rationale.semanticContext,
+          metaphor: {
+            ...entry!.rationale.semanticContext.metaphor,
+            visualCue: 'doesNotExist' as never,
+          },
+        },
+      },
+    });
+
+    expect(errors).toContain(
+      'button-feedback-success: invalid rationale.semanticContext.metaphor.visualCue "doesNotExist"',
     );
   });
 });

--- a/prototyp/src/framework/validation.ts
+++ b/prototyp/src/framework/validation.ts
@@ -1,9 +1,10 @@
-import { mappings } from "../data/mappings";
+import { mappings } from '../data/mappings';
 import {
   COMPONENT_IDS,
   DIMENSIONS,
   SUBCATEGORIES_BY_DIMENSION,
-} from "./types";
+  VISUAL_CUE_IDS,
+} from './types';
 import type {
   ComponentId,
   Dimension,
@@ -14,16 +15,18 @@ import type {
   MotionPhase,
   ReducedMotionStrategy,
   ScaleMode,
+  SemanticContext,
   SpringConfig,
   Subcategory,
   TranslationEdge,
-} from "./types";
+  VisualCueId,
+} from './types';
 import {
   getMapping,
   getMappingCount,
   getOutOfScopeCombinations,
   getSupportedComponents,
-} from "./classifier";
+} from './classifier';
 
 export type ValidationReport = {
   totalEntries: number;
@@ -35,15 +38,16 @@ export type ValidationReport = {
 
 const componentIds = new Set<ComponentId>(COMPONENT_IDS);
 const dimensions = new Set<Dimension>(DIMENSIONS);
-const xEdges = new Set<TranslationEdge>(["left", "right"]);
-const yEdges = new Set<TranslationEdge>(["top", "bottom"]);
+const xEdges = new Set<TranslationEdge>(['left', 'right']);
+const yEdges = new Set<TranslationEdge>(['top', 'bottom']);
 const reducedMotionStrategies = new Set<ReducedMotionStrategy>([
-  "none",
-  "shorten",
-  "replace",
-  "static",
+  'none',
+  'shorten',
+  'replace',
+  'static',
 ]);
-const scaleModes = new Set<ScaleMode>(["pulse", "scaleIn", "scaleOut"]);
+const scaleModes = new Set<ScaleMode>(['pulse', 'scaleIn', 'scaleOut']);
+const visualCueIds = new Set<VisualCueId>(VISUAL_CUE_IDS);
 const durationTolerance = 0.001;
 
 function isFiniteNumber(value: number): boolean {
@@ -131,7 +135,7 @@ function validateEasing(
 ): string[] {
   const errors: string[] = [];
 
-  if ("preset" in easing) {
+  if ('preset' in easing) {
     return errors;
   }
 
@@ -151,7 +155,9 @@ function validateEasing(
   const [x1, , x2] = cubicBezier;
 
   if (x1 < 0 || x1 > 1 || x2 < 0 || x2 > 1) {
-    errors.push(`${ownerId}: ${label}.cubicBezier x values must be between 0 and 1`);
+    errors.push(
+      `${ownerId}: ${label}.cubicBezier x values must be between 0 and 1`,
+    );
   }
 
   return errors;
@@ -167,8 +173,16 @@ function validateSpringConfig(
   }
 
   return [
-    ...validatePositiveNumber(ownerId, `${label}.stiffness`, springConfig.stiffness),
-    ...validatePositiveNumber(ownerId, `${label}.damping`, springConfig.damping),
+    ...validatePositiveNumber(
+      ownerId,
+      `${label}.stiffness`,
+      springConfig.stiffness,
+    ),
+    ...validatePositiveNumber(
+      ownerId,
+      `${label}.damping`,
+      springConfig.damping,
+    ),
     ...validatePositiveNumber(ownerId, `${label}.mass`, springConfig.mass),
   ];
 }
@@ -209,7 +223,9 @@ function validateKeyframeSequence(
 
   times.forEach((time, index) => {
     if (!isFiniteNumber(time) || time < 0 || time > 1) {
-      errors.push(`${entryId}: ${label} times[${index}] must be between 0 and 1`);
+      errors.push(
+        `${entryId}: ${label} times[${index}] must be between 0 and 1`,
+      );
     }
   });
 
@@ -224,7 +240,7 @@ function validateKeyframeSequence(
 
 function validateTranslationEdges(
   ownerId: string,
-  direction: "x" | "y" | undefined,
+  direction: 'x' | 'y' | undefined,
   translateFrom: TranslationEdge | undefined,
   translateTo: TranslationEdge | undefined,
 ): string[] {
@@ -234,14 +250,18 @@ function validateTranslationEdges(
     return errors;
   }
 
-  const allowedEdges = direction === "x" ? xEdges : yEdges;
+  const allowedEdges = direction === 'x' ? xEdges : yEdges;
 
   if (translateFrom !== undefined && !allowedEdges.has(translateFrom)) {
-    errors.push(`${ownerId}: translateFrom does not match direction "${direction}"`);
+    errors.push(
+      `${ownerId}: translateFrom does not match direction "${direction}"`,
+    );
   }
 
   if (translateTo !== undefined && !allowedEdges.has(translateTo)) {
-    errors.push(`${ownerId}: translateTo does not match direction "${direction}"`);
+    errors.push(
+      `${ownerId}: translateTo does not match direction "${direction}"`,
+    );
   }
 
   return errors;
@@ -267,7 +287,9 @@ function validateSharedPhaseTimes(
 
   const [firstSequence, ...otherSequences] = sequences;
 
-  if (otherSequences.some((sequence) => !hasSameTimes(firstSequence, sequence))) {
+  if (
+    otherSequences.some((sequence) => !hasSameTimes(firstSequence, sequence))
+  ) {
     return [
       `${phaseId}: multiple keyframe sequences in one phase must share the same times`,
     ];
@@ -298,8 +320,12 @@ function validateMotionPhase(
     errors.push(`${entry.id}: motion phase requires id`);
   }
 
-  errors.push(...validatePositiveNumber(phaseId, "motion phase duration", phase.duration));
-  errors.push(...validateNonNegativeNumber(phaseId, "motion phase delay", phase.delay));
+  errors.push(
+    ...validatePositiveNumber(phaseId, 'motion phase duration', phase.duration),
+  );
+  errors.push(
+    ...validateNonNegativeNumber(phaseId, 'motion phase delay', phase.delay),
+  );
 
   if (!phaseHasAnyMotion) {
     errors.push(`${phaseId}: motion phase must define motion or opacity`);
@@ -339,16 +365,16 @@ function validateMotionPhase(
   );
 
   if (phase.easing !== undefined) {
-    errors.push(...validateEasing(phaseId, "easing", phase.easing));
+    errors.push(...validateEasing(phaseId, 'easing', phase.easing));
   }
 
   if (phase.opacity !== undefined) {
-    errors.push(...validateOpacityRange(phaseId, "opacity", phase.opacity));
+    errors.push(...validateOpacityRange(phaseId, 'opacity', phase.opacity));
   }
 
   if (phase.keyframes !== undefined) {
     errors.push(
-      ...validateKeyframeSequence(phaseId, "keyframe", phase.keyframes),
+      ...validateKeyframeSequence(phaseId, 'keyframe', phase.keyframes),
     );
   }
 
@@ -356,7 +382,7 @@ function validateMotionPhase(
     errors.push(
       ...validateKeyframeSequence(
         phaseId,
-        "scale keyframe",
+        'scale keyframe',
         phase.scaleKeyframes,
       ),
     );
@@ -366,7 +392,7 @@ function validateMotionPhase(
     errors.push(
       ...validateKeyframeSequence(
         phaseId,
-        "opacity keyframe",
+        'opacity keyframe',
         phase.opacityKeyframes,
         { opacityValues: true },
       ),
@@ -382,8 +408,7 @@ function validateMotionPhase(
   errors.push(...validateSharedPhaseTimes(phaseId, keyframeSequences));
 
   const phaseEasing = phase.easing ?? entry.params.easing;
-  const usesSpring =
-    "preset" in phaseEasing && phaseEasing.preset === "spring";
+  const usesSpring = 'preset' in phaseEasing && phaseEasing.preset === 'spring';
 
   if (
     usesSpring &&
@@ -399,23 +424,27 @@ function validateMotionPhase(
     );
   }
 
-  errors.push(...validateSpringConfig(phaseId, "springConfig", phase.springConfig));
+  errors.push(
+    ...validateSpringConfig(phaseId, 'springConfig', phase.springConfig),
+  );
 
   return errors;
 }
 
 function usesComponentSpecificRenderer(entry: MappingEntry): boolean {
   return (
-    entry.component === "input" &&
-    entry.dimension === "stateChange" &&
-    (entry.subcategory === "focus" || entry.subcategory === "blur")
+    entry.component === 'input' &&
+    entry.dimension === 'stateChange' &&
+    (entry.subcategory === 'focus' || entry.subcategory === 'blur')
   );
 }
 
 function requiresReducedMotionStrategy(entry: MappingEntry): boolean {
   const { iterations } = entry.params;
 
-  return iterations === Infinity || (iterations !== undefined && iterations > 1);
+  return (
+    iterations === Infinity || (iterations !== undefined && iterations > 1)
+  );
 }
 
 function validateAccessibility(entry: MappingEntry): string[] {
@@ -437,6 +466,92 @@ function validateAccessibility(entry: MappingEntry): string[] {
   }
 
   return errors;
+}
+
+function validateNonEmptyText(
+  entryId: string,
+  label: string,
+  value: string | undefined,
+): string[] {
+  if (value === undefined || !value.trim()) {
+    return [`${entryId}: missing ${label}`];
+  }
+
+  return [];
+}
+
+function validateNonEmptyTextArray(
+  entryId: string,
+  label: string,
+  values: string[] | undefined,
+): string[] {
+  const errors: string[] = [];
+
+  if (values === undefined || values.length === 0) {
+    return [`${entryId}: ${label} must not be empty`];
+  }
+
+  values.forEach((value, index) => {
+    if (!value.trim()) {
+      errors.push(`${entryId}: ${label}[${index}] must not be empty`);
+    }
+  });
+
+  return errors;
+}
+
+function validateVisualCue(
+  entryId: string,
+  visualCue: VisualCueId | VisualCueId[] | undefined,
+): string[] {
+  const errors: string[] = [];
+  const label = 'rationale.semanticContext.metaphor.visualCue';
+  const cues = Array.isArray(visualCue) ? visualCue : [visualCue];
+
+  if (visualCue === undefined || cues.length === 0) {
+    return [`${entryId}: ${label} must not be empty`];
+  }
+
+  cues.forEach((cue) => {
+    if (cue === undefined || !visualCueIds.has(cue)) {
+      errors.push(`${entryId}: invalid ${label} "${String(cue)}"`);
+    }
+  });
+
+  return errors;
+}
+
+function validateSemanticContext(
+  entryId: string,
+  semanticContext: SemanticContext | undefined,
+): string[] {
+  if (semanticContext === undefined) {
+    return [`${entryId}: missing rationale.semanticContext`];
+  }
+
+  return [
+    ...validateNonEmptyText(
+      entryId,
+      'rationale.semanticContext.metaphor.label',
+      semanticContext.metaphor?.label,
+    ),
+    ...validateVisualCue(entryId, semanticContext.metaphor?.visualCue),
+    ...validateNonEmptyText(
+      entryId,
+      'rationale.semanticContext.primaryReading',
+      semanticContext.primaryReading,
+    ),
+    ...validateNonEmptyTextArray(
+      entryId,
+      'rationale.semanticContext.adjacentReadings',
+      semanticContext.adjacentReadings,
+    ),
+    ...validateNonEmptyTextArray(
+      entryId,
+      'rationale.semanticContext.boundaries',
+      semanticContext.boundaries,
+    ),
+  ];
 }
 
 export function validateMappingEntry(entry: MappingEntry): string[] {
@@ -479,6 +594,10 @@ export function validateMappingEntry(entry: MappingEntry): string[] {
     errors.push(`${entry.id}: missing rationale.references`);
   }
 
+  errors.push(
+    ...validateSemanticContext(entry.id, entry.rationale.semanticContext),
+  );
+
   const params = entry.params;
   const hasTranslation =
     params.translatePx !== undefined ||
@@ -494,10 +613,10 @@ export function validateMappingEntry(entry: MappingEntry): string[] {
   const hasMotionPhases = params.motionPhases !== undefined;
   const movementGroups = [hasTranslation, hasScale, hasTrack].filter(Boolean);
 
-  errors.push(...validatePositiveNumber(entry.id, "duration", params.duration));
-  errors.push(...validateNonNegativeNumber(entry.id, "delay", params.delay));
+  errors.push(...validatePositiveNumber(entry.id, 'duration', params.duration));
+  errors.push(...validateNonNegativeNumber(entry.id, 'delay', params.delay));
   errors.push(...validateIterations(entry.id, params.iterations));
-  errors.push(...validateEasing(entry.id, "easing", params.easing));
+  errors.push(...validateEasing(entry.id, 'easing', params.easing));
   errors.push(...validateAccessibility(entry));
 
   if (movementGroups.length > 1) {
@@ -593,7 +712,7 @@ export function validateMappingEntry(entry: MappingEntry): string[] {
   );
 
   const usesSpring =
-    "preset" in params.easing && params.easing.preset === "spring";
+    'preset' in params.easing && params.easing.preset === 'spring';
 
   if (usesSpring && params.springConfig === undefined) {
     errors.push(`${entry.id}: spring easing requires springConfig`);
@@ -605,15 +724,17 @@ export function validateMappingEntry(entry: MappingEntry): string[] {
     );
   }
 
-  errors.push(...validateSpringConfig(entry.id, "springConfig", params.springConfig));
+  errors.push(
+    ...validateSpringConfig(entry.id, 'springConfig', params.springConfig),
+  );
 
   if (params.opacity !== undefined) {
-    errors.push(...validateOpacityRange(entry.id, "opacity", params.opacity));
+    errors.push(...validateOpacityRange(entry.id, 'opacity', params.opacity));
   }
 
   if (params.keyframes !== undefined) {
     errors.push(
-      ...validateKeyframeSequence(entry.id, "keyframe", params.keyframes),
+      ...validateKeyframeSequence(entry.id, 'keyframe', params.keyframes),
     );
   }
 
@@ -621,7 +742,7 @@ export function validateMappingEntry(entry: MappingEntry): string[] {
     errors.push(
       ...validateKeyframeSequence(
         entry.id,
-        "opacity keyframe",
+        'opacity keyframe',
         params.opacityKeyframes,
         { opacityValues: true },
       ),
@@ -702,7 +823,7 @@ export function validateMappingDatabase(): ValidationReport {
   }
 
   if (getMappingCount() !== mappings.length) {
-    errors.push("classifier count differs from mappings length");
+    errors.push('classifier count differs from mappings length');
   }
 
   return {

--- a/prototyp/src/framework/visualCues.ts
+++ b/prototyp/src/framework/visualCues.ts
@@ -1,0 +1,70 @@
+import { VISUAL_CUE_IDS } from './types';
+import type { VisualCueId } from './types';
+
+export interface VisualCuePlaceholder {
+  lucideIcon: string;
+  note: string;
+}
+
+/**
+ * Vorläufige Icon-Zuordnung für die semantischen Visual Cues.
+ * Diese Datei koppelt die Mapping-Daten nicht an Lucide. Die Strings sind nur
+ * Platzhalter, bis eigene Glyphs oder konkrete Icon-Komponenten eingeführt
+ * werden.
+ */
+export const lucidePlaceholderByVisualCueId = {
+  refusalGesture: {
+    lucideIcon: 'Ban',
+    note: 'Platzhalter für Ablehnung. Später wahrscheinlich durch eigenes Gesture-Glyph ersetzen.',
+  },
+  pulseSignal: {
+    lucideIcon: 'Activity',
+    note: 'Platzhalter für kurzen Bedeutungsimpuls oder wiederholtes Sich-Bemerkbar-Machen.',
+  },
+  toggleTravel: {
+    lucideIcon: 'ToggleRight',
+    note: 'Platzhalter für den physisch lesbaren Wechsel zwischen Toggle-Zuständen.',
+  },
+  arrival: {
+    lucideIcon: 'LogIn',
+    note: 'Platzhalter für gerichtetes Eintreten oder Ankommen eines UI-Elements.',
+  },
+  departure: {
+    lucideIcon: 'LogOut',
+    note: 'Platzhalter für gerichtetes Verlassen oder Ausfahren eines UI-Elements.',
+  },
+  nudgeSignal: {
+    lucideIcon: 'BellRing',
+    note: 'Platzhalter für moderates Hinweis- oder Warnsignal ohne Fehlergeste.',
+  },
+  returnLayer: {
+    lucideIcon: 'Undo2',
+    note: 'Platzhalter für Rückkehrbewegung im horizontalen Navigationsraum.',
+  },
+  foreground: {
+    lucideIcon: 'BringToFront',
+    note: 'Platzhalter für Vordergrundpriorität und visuelles Herantreten.',
+  },
+  backgroundRecede: {
+    lucideIcon: 'SendToBack',
+    note: 'Platzhalter für Zurücktreten oder Verlust der Vordergrundpriorität.',
+  },
+  focusSignal: {
+    lucideIcon: 'Focus',
+    note: 'Platzhalter für aktiven oder zurücktretenden Fokuszustand.',
+  },
+  helperMessage: {
+    lucideIcon: 'MessageSquareWarning',
+    note: 'Platzhalter für lokalen Hinweis- oder Warntext am Eingabefeld.',
+  },
+  shimmerSignal: {
+    lucideIcon: 'ScanLine',
+    note: 'Platzhalter für wandernden Shimmer oder zeilenartigen Ladeindikator.',
+  },
+  fadeResolve: {
+    lucideIcon: 'EyeOff',
+    note: 'Platzhalter für visuelles Verschwinden oder Auflösen eines Platzhalters.',
+  },
+} satisfies Record<VisualCueId, VisualCuePlaceholder>;
+
+export const visualCueIds = [...VISUAL_CUE_IDS];

--- a/prototyp/src/pages/Editor.tsx
+++ b/prototyp/src/pages/Editor.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { AnimatePresence } from 'framer-motion';
 import MotionActionButton from '../components/MotionActionButton';
 import SourceTooltip from '../components/SourceTooltip';
 import EditorExportPanel from '../editor/export/EditorExportPanel';
+import SemanticContextPanel from '../editor/SemanticContextPanel';
 import EditorPreview from '../editor/preview/EditorPreview';
 import { getPreviewChoreography } from '../editor/preview/previewChoreography';
 import {
@@ -36,6 +38,7 @@ export type EditorSelection = {
 type EditorProps = {
   selection: EditorSelection;
   onSelectionChange: (selection: EditorSelection) => void;
+  showSemanticContext: boolean;
 };
 
 type MobilePicker = 'component' | 'dimension' | 'subcategory';
@@ -51,7 +54,9 @@ function getFirstSubcategory(component: ComponentId, dimension: Dimension) {
   );
 }
 
-function getReplayCooldownMs(entry: NonNullable<ReturnType<typeof getMapping>>) {
+function getReplayCooldownMs(
+  entry: NonNullable<ReturnType<typeof getMapping>>,
+) {
   const phases = entry.params.motionPhases;
   const choreography = getPreviewChoreography(entry);
   const animationDuration =
@@ -77,21 +82,28 @@ export const defaultEditorSelection: EditorSelection = {
   ),
 };
 
-function Editor({ selection, onSelectionChange }: EditorProps) {
+function Editor({
+  selection,
+  onSelectionChange,
+  showSemanticContext,
+}: EditorProps) {
   const [replayKey, setReplayKey] = useState(0);
   const [isReplayCoolingDown, setIsReplayCoolingDown] = useState(false);
-  const [openMobilePicker, setOpenMobilePicker] =
-    useState<MobilePicker | null>(null);
+  const [openMobilePicker, setOpenMobilePicker] = useState<MobilePicker | null>(
+    null,
+  );
   const replayCooldownRef = useRef<number | null>(null);
   const { component, dimension, subcategory } = selection;
 
   const validationReport = useMemo(() => validateMappingDatabase(), []);
   const selectedEntry = getMapping({ component, dimension, subcategory });
-  const entry = selectedEntry ?? getMapping({
-    component: defaultComponent,
-    dimension: 'feedback',
-    subcategory: 'success',
-  });
+  const entry =
+    selectedEntry ??
+    getMapping({
+      component: defaultComponent,
+      dimension: 'feedback',
+      subcategory: 'success',
+    });
 
   const clearReplayCooldown = () => {
     if (replayCooldownRef.current !== null) {
@@ -372,6 +384,15 @@ function Editor({ selection, onSelectionChange }: EditorProps) {
               ))}
             </div>
           </section>
+
+          <AnimatePresence initial={false}>
+            {showSemanticContext && (
+              <SemanticContextPanel
+                key="semantic-context"
+                semanticContext={entry.rationale.semanticContext}
+              />
+            )}
+          </AnimatePresence>
 
           <EditorExportPanel entry={entry} />
         </aside>


### PR DESCRIPTION
Adds semanticContext metadata for all mappings, visual cue validation, and the optional Semantischer Möglichkeitsraum panel in the editor.

Documents the concept in ADRs and week 04 notes, and adds Prettier for formatting.